### PR TITLE
Fix func count for dtype O with numpy and numba

### DIFF
--- a/flox/xarray.py
+++ b/flox/xarray.py
@@ -296,7 +296,7 @@ def xarray_reduce(
             if "nan" not in func and func not in ["all", "any", "count"]:
                 func = f"nan{func}"
 
-        requires_numeric = func not in ["count", "any", "all"]
+        requires_numeric = func not in ["any", "all"]
         if requires_numeric:
             is_npdatetime = array.dtype.kind in "Mm"
             is_cftime = _contains_cftime_datetimes(array)
@@ -311,7 +311,7 @@ def xarray_reduce(
 
         result, *groups = groupby_reduce(array, *by, func=func, **kwargs)
 
-        if requires_numeric:
+        if requires_numeric and func != 'count':
             if is_npdatetime:
                 return result.astype(dtype) + offset
             elif is_cftime:

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -420,7 +420,7 @@ def test_cache():
 
 @pytest.mark.parametrize("use_cftime", [True, False])
 @pytest.mark.parametrize("func", ["count", "mean"])
-def test_datetime_array_reduce(use_cftime, func):
+def test_datetime_array_reduce(use_cftime, func, engine):
 
     time = xr.DataArray(
         xr.date_range("2009-01-01", "2012-12-31", use_cftime=use_cftime),
@@ -428,7 +428,7 @@ def test_datetime_array_reduce(use_cftime, func):
         name="time",
     )
     expected = getattr(time.resample(time="YS"), func)()
-    actual = resample_reduce(time.resample(time="YS"), func=func, engine="flox")
+    actual = resample_reduce(time.resample(time="YS"), func=func, engine=engine)
     assert_equal(expected, actual)
 
 


### PR DESCRIPTION
This fixes #137.

# Changes
- Generalized the datetime reduce test so it tests all engines.
- When `func='count'` and `engine != 'flox'`, `requires_numeric` becomes True, which avoid type errors in numba and numpy.

# Performance
The "flox" engine is not included because I saw a loss of performance in my (small) tests. 
```python3
import xarray as xr
from flox.xarray import xarray_reduce

t = xr.DataArray(xr.cftime_range('1900-01-01', periods=100000, freq='H'), dims=('time',))
xarray_reduce(t, t.dt.month, func='count', engine=ENGINE)
```
With engine 'flox', this code was around 10% slower if I added the numeric conversion.