### PR TITLE
Remove None output from _get_expected_groups

### DIFF
--- a/flox/core.py
+++ b/flox/core.py
@@ -1149,13 +1149,13 @@ def dask_groupby_agg(
         )
     else:
         intermediate = applied
-        if not is_duck_dask_array(by_input):
-            expected_groups = _get_expected_groups(by_input, sort=sort)
-            group_chunks = ((len(expected_groups),),)
-        else:
+        if is_duck_dask_array(by_input):
             expected_groups = None
-            group_chunks = ((np.nan,),)
-
+            # group_chunks = ((np.nan,),)
+        else:
+            expected_groups = _get_expected_groups(by_input, sort=sort)
+            # group_chunks = ((len(expected_groups),),)
+        group_chunks = ((len(expected_groups),) if expected_groups is not None else (np.nan,),)
     if method == "map-reduce":
         # these are negative axis indices useful for concatenating the intermediates
         neg_axis = tuple(range(-len(axis), 0))

--- a/flox/core.py
+++ b/flox/core.py
@@ -1154,11 +1154,8 @@ def dask_groupby_agg(
         if expected_groups is None:
             if is_duck_dask_array(by_input):
                 expected_groups = None
-                # group_chunks = ((np.nan,),)
             else:
                 expected_groups = _get_expected_groups(by_input, sort=sort)
-                # group_chunks = ((len(expected_groups),),)
-            # expected_groups = _get_expected_groups(by_input, sort=sort, raise_if_dask=False)
         group_chunks = ((len(expected_groups),) if expected_groups is not None else (np.nan,),)
 
     if method == "map-reduce":

--- a/flox/core.py
+++ b/flox/core.py
@@ -1151,13 +1151,14 @@ def dask_groupby_agg(
         )
     else:
         intermediate = applied
-        # if is_duck_dask_array(by_input):
-        #     expected_groups = None
-        #     # group_chunks = ((np.nan,),)
-        # else:
-        #     expected_groups = _get_expected_groups(by_input, sort=sort)
-        #     # group_chunks = ((len(expected_groups),),)
-        expected_groups = _get_expected_groups(by_input, sort=sort, raise_if_dask=False)
+        if expected_groups is None:
+            if is_duck_dask_array(by_input):
+                expected_groups = None
+                # group_chunks = ((np.nan,),)
+            else:
+                expected_groups = _get_expected_groups(by_input, sort=sort)
+                # group_chunks = ((len(expected_groups),),)
+            # expected_groups = _get_expected_groups(by_input, sort=sort, raise_if_dask=False)
         group_chunks = ((len(expected_groups),) if expected_groups is not None else (np.nan,),)
 
     if method == "map-reduce":

--- a/flox/core.py
+++ b/flox/core.py
@@ -1149,9 +1149,12 @@ def dask_groupby_agg(
         )
     else:
         intermediate = applied
-        if expected_groups is None:
-            expected_groups = _get_expected_groups(by_input, sort=sort, raise_if_dask=False)
-        group_chunks = ((len(expected_groups),) if expected_groups is not None else (np.nan,),)
+        if not is_duck_dask_array(by_input):
+            expected_groups = _get_expected_groups(by_input, sort=sort)
+            group_chunks = ((len(expected_groups),),)
+        else:
+            expected_groups = None
+            group_chunks = ((np.nan,),)
 
     if method == "map-reduce":
         # these are negative axis indices useful for concatenating the intermediates

--- a/flox/core.py
+++ b/flox/core.py
@@ -1155,6 +1155,7 @@ def dask_groupby_agg(
         else:
             expected_groups = _get_expected_groups(by_input, sort=sort)
             # group_chunks = ((len(expected_groups),),)
+
         group_chunks = ((len(expected_groups),) if expected_groups is not None else (np.nan,),)
     if method == "map-reduce":
         # these are negative axis indices useful for concatenating the intermediates

--- a/flox/core.py
+++ b/flox/core.py
@@ -56,7 +56,9 @@ def _is_arg_reduction(func: str | Aggregation) -> bool:
 
 def _get_expected_groups(by, sort: bool, *, raise_if_dask=True) -> pd.Index:
     if is_duck_dask_array(by):
-        raise ValueError("Please provide expected_groups if not grouping by a numpy array.")
+        if raise_if_dask:
+            raise ValueError("Please provide expected_groups if not grouping by a numpy array.")
+        return None
     flatby = by.reshape(-1)
     expected = pd.unique(flatby[~isnull(flatby)])
     return _convert_expected_groups_to_index((expected,), isbin=(False,), sort=sort)[0]

--- a/flox/core.py
+++ b/flox/core.py
@@ -54,11 +54,9 @@ def _is_arg_reduction(func: str | Aggregation) -> bool:
     return False
 
 
-def _get_expected_groups(by, sort, *, raise_if_dask=True) -> pd.Index | None:
+def _get_expected_groups(by, sort: bool) -> pd.Index:
     if is_duck_dask_array(by):
-        if raise_if_dask:
-            raise ValueError("Please provide expected_groups if not grouping by a numpy array.")
-        return None
+        raise ValueError("Please provide expected_groups if not grouping by a numpy array.")
     flatby = by.reshape(-1)
     expected = pd.unique(flatby[~isnull(flatby)])
     return _convert_expected_groups_to_index((expected,), isbin=(False,), sort=sort)[0]

--- a/flox/core.py
+++ b/flox/core.py
@@ -54,7 +54,7 @@ def _is_arg_reduction(func: str | Aggregation) -> bool:
     return False
 
 
-def _get_expected_groups(by, sort: bool) -> pd.Index:
+def _get_expected_groups(by, sort: bool, *, raise_if_dask=True) -> pd.Index:
     if is_duck_dask_array(by):
         raise ValueError("Please provide expected_groups if not grouping by a numpy array.")
     flatby = by.reshape(-1)
@@ -1149,12 +1149,13 @@ def dask_groupby_agg(
         )
     else:
         intermediate = applied
-        if is_duck_dask_array(by_input):
-            expected_groups = None
-            # group_chunks = ((np.nan,),)
-        else:
-            expected_groups = _get_expected_groups(by_input, sort=sort)
-            # group_chunks = ((len(expected_groups),),)
+        # if is_duck_dask_array(by_input):
+        #     expected_groups = None
+        #     # group_chunks = ((np.nan,),)
+        # else:
+        #     expected_groups = _get_expected_groups(by_input, sort=sort)
+        #     # group_chunks = ((len(expected_groups),),)
+        expected_groups = _get_expected_groups(by_input, sort=sort, raise_if_dask=False)
         group_chunks = ((len(expected_groups),) if expected_groups is not None else (np.nan,),)
 
     if method == "map-reduce":

--- a/flox/core.py
+++ b/flox/core.py
@@ -1155,8 +1155,8 @@ def dask_groupby_agg(
         else:
             expected_groups = _get_expected_groups(by_input, sort=sort)
             # group_chunks = ((len(expected_groups),),)
-
         group_chunks = ((len(expected_groups),) if expected_groups is not None else (np.nan,),)
+
     if method == "map-reduce":
         # these are negative axis indices useful for concatenating the intermediates
         neg_axis = tuple(range(-len(axis), 0))

--- a/flox/core.py
+++ b/flox/core.py
@@ -54,11 +54,9 @@ def _is_arg_reduction(func: str | Aggregation) -> bool:
     return False
 
 
-def _get_expected_groups(by, sort: bool, *, raise_if_dask=True) -> pd.Index:
+def _get_expected_groups(by, sort: bool) -> pd.Index:
     if is_duck_dask_array(by):
-        if raise_if_dask:
-            raise ValueError("Please provide expected_groups if not grouping by a numpy array.")
-        return None
+        raise ValueError("Please provide expected_groups if not grouping by a numpy array.")
     flatby = by.reshape(-1)
     expected = pd.unique(flatby[~isnull(flatby)])
     return _convert_expected_groups_to_index((expected,), isbin=(False,), sort=sort)[0]

--- a/flox/xarray.py
+++ b/flox/xarray.py
@@ -313,7 +313,7 @@ def xarray_reduce(
                     f"Please provided bin edges for group variable {idx} "
                     f"named {group_name} in expected_groups."
                 )
-            expect_ = _get_expected_groups(b_.data, sort=sort, raise_if_dask=True)
+            expect_ = _get_expected_groups(b_.data, sort=sort)
         else:
             expect_ = expect
         expect_index = _convert_expected_groups_to_index((expect_,), (isbin_,), sort=sort)[0]


### PR DESCRIPTION
Simplifies typing and the `raise_if_dask` argument was only used once.