### PR TITLE
More efficient cohorts.

### DIFF
--- a/docs/source/implementation.md
+++ b/docs/source/implementation.md
@@ -13,7 +13,7 @@ or `xarray_reduce`.
 
 First we describe xarray's current strategy
 
-## `method="split-reduce"`: Xarray's current GroupBy strategy
+## Background: Xarray's current GroupBy strategy
 
 Xarray's current strategy is to find all unique group labels, index out each group,
 and then apply the reduction operation. Note that this only works if we know the group

--- a/flox/core.py
+++ b/flox/core.py
@@ -1091,13 +1091,13 @@ def subset_to_blocks(
     for ax, idx in enumerate(unraveled):
         i = np.unique(idx).squeeze()
         if i.ndim == 0:
-            i = i.item()
+            i_ = i.item()
         else:
             if np.array_equal(i, np.arange(blkshape[ax])):
-                i = slice(None)
+                i_ = slice(None)
             elif np.array_equal(i, np.arange(i[0], i[-1] + 1)):
-                i = slice(i[0], i[-1] + 1)
-        normalized.append(i)
+                i_ = slice(i[0], i[-1] + 1)
+        normalized.append(i_)
     full_normalized = (slice(None),) * (array.ndim - len(normalized)) + tuple(normalized)
 
     # has no iterables

--- a/flox/core.py
+++ b/flox/core.py
@@ -1124,6 +1124,37 @@ def subset_to_blocks(
     return subset
 
 
+def reduce_cohorts(array, cohort, tree_reduce, do_simple_combine, reindex, agg, aggregate):
+    """Loop over multiple "cohorts" and apply the reduction. The loop is only
+    used for split-reduce."""
+    import dask.array
+
+    reduced = []
+    groups = []
+    for member in cohort:
+        member1d = np.atleast_1d(member)
+        if do_simple_combine:
+            # reindex so that reindex can be set to True later
+            reindexed = dask.array.map_blocks(
+                reindex_intermediates,
+                array,
+                agg=agg,
+                unique_groups=member1d,
+                meta=array._meta,
+            )
+        else:
+            reindexed = array
+
+        reduced.append(
+            tree_reduce(
+                reindexed,
+                aggregate=partial(aggregate, expected_groups=member1d, reindex=reindex),
+            )
+        )
+        groups.append(member1d)
+    return reduced, groups
+
+
 def _extract_unknown_groups(reduced, group_chunks, dtype) -> tuple[DaskArray]:
     import dask.array
     from dask.highlevelgraph import HighLevelGraph
@@ -1318,25 +1349,17 @@ def dask_groupby_agg(
             for blks, cohort in chunks_cohorts.items():
                 cohort = sorted(cohort)
                 subset = subset_to_blocks(intermediate, blks, array.blocks.shape[-len(axis) :])
-                if do_simple_combine:
-                    # reindex so that reindex can be set to True later
-                    reindexed = dask.array.map_blocks(
-                        reindex_intermediates,
-                        subset,
-                        agg=agg,
-                        unique_groups=cohort,
-                        meta=subset._meta,
-                    )
-                else:
-                    reindexed = subset
-
-                reduced_.append(
-                    tree_reduce(
-                        reindexed,
-                        aggregate=partial(aggregate, expected_groups=cohort, reindex=reindex),
-                    )
+                r, g = reduce_cohorts(
+                    subset,
+                    (cohort,) if method == "cohorts" else cohort,
+                    tree_reduce,
+                    do_simple_combine,
+                    reindex,
+                    agg,
+                    aggregate,
                 )
-                groups_.append(cohort)
+                reduced_.extend(r)
+                groups_.extend(g)
 
             reduced = dask.array.concatenate(reduced_, axis=-1)
             groups = (np.concatenate(groups_),)
@@ -1751,6 +1774,7 @@ def groupby_reduce(
 
         if sort and method != "map-reduce":
             assert len(groups) == 1
+            assert groups[0].ndim == 1
             sorted_idx = np.argsort(groups[0])
             result = result[..., sorted_idx]
             groups = (groups[0][sorted_idx],)

--- a/flox/core.py
+++ b/flox/core.py
@@ -1317,7 +1317,7 @@ def dask_groupby_agg(
 
         elif method in ["cohorts", "split-reduce"]:
             chunks_cohorts = find_group_cohorts(
-                by_input, [array.chunks[ax] for ax in axis], merge=True, method=method
+                by_input, [array.chunks[ax] for ax in axis], merge=True
             )
             reduced_ = []
             groups_ = []

--- a/flox/core.py
+++ b/flox/core.py
@@ -1359,12 +1359,11 @@ def dask_groupby_agg(
                 nblocks = tuple(len(array.chunks[ax]) for ax in axis)
                 inchunk = ochunk[:-1] + np.unravel_index(ochunk[-1], nblocks)
         else:
-            inchunk = (
-                ochunk[:-1]
-                + (0,) * (len(axis) - 1)
-                + (ochunk[-1],)  # always 0 for map-reduce, something else for cohorts, split-reduce
-                + (ochunk[-1],) * int((split_out > 1))
-            )
+            inchunk = ochunk[:-1] + (0,) * (len(axis) - 1)
+            if split_out > 1:
+                inchunk = inchunk + (0,)
+            inchunk = inchunk + (ochunk[-1],)
+
         layer2[(agg_name, *ochunk)] = (operator.getitem, (reduced.name, *inchunk), agg.name)
 
     result = dask.array.Array(

--- a/flox/core.py
+++ b/flox/core.py
@@ -193,7 +193,7 @@ def find_group_cohorts(labels, chunks, merge: bool = True, method: T_MethodCohor
     if merge:
         # First sort by number of chunks occupied by cohort
         sorted_chunks_cohorts = dict(
-            reversed(sorted(chunks_cohorts.items(), key=lambda kv: len(kv[0])))
+            sorted(chunks_cohorts.items(), key=lambda kv: len(kv[0]), reverse=True)
         )
 
         items = tuple(sorted_chunks_cohorts.items())
@@ -216,7 +216,13 @@ def find_group_cohorts(labels, chunks, merge: bool = True, method: T_MethodCohor
                     merged_cohorts[k1].extend(v2)
                     merged_keys.append(k2)
 
-        return merged_cohorts
+        # make sure each cohort is sorted after merging
+        sorted_merged_cohorts = {k: sorted(v) for k, v in merged_cohorts.items()}
+        # sort by first label in cohort
+        # This will help when sort=True (default)
+        # and we have to resort the dask array
+        return dict(sorted(sorted_merged_cohorts.items(), key=lambda kv: kv[1][0]))
+
     else:
         return chunks_cohorts
 
@@ -1347,7 +1353,6 @@ def dask_groupby_agg(
             reduced_ = []
             groups_ = []
             for blks, cohort in chunks_cohorts.items():
-                cohort = sorted(cohort)
                 subset = subset_to_blocks(intermediate, blks, array.blocks.shape[-len(axis) :])
                 r, g = reduce_cohorts(
                     subset,

--- a/flox/core.py
+++ b/flox/core.py
@@ -1321,7 +1321,6 @@ def dask_groupby_agg(
             reduced = dask.array.concatenate(reduced_, axis=-1)
             groups = (np.concatenate(groups_),)
             group_chunks = (tuple(len(cohort) for cohort in groups_),)
-            # compute_blocks(reduced)
 
     elif method == "blockwise":
         reduced = intermediate

--- a/flox/core.py
+++ b/flox/core.py
@@ -138,7 +138,7 @@ def _get_optimal_chunks_for_groups(chunks, labels):
 
 
 @memoize
-def find_group_cohorts(labels, chunks, merge: bool = True, method: T_MethodCohorts = "cohorts"):
+def find_group_cohorts(labels, chunks, merge: bool = True):
     """
     Finds groups labels that occur together aka "cohorts"
 
@@ -1570,9 +1570,7 @@ def groupby_reduce(
             method by first rechunking using ``rechunk_for_cohorts``
             (for 1D ``by`` only).
           * ``"split-reduce"``:
-            Break out each group into its own array and then ``"map-reduce"``.
-            This is implemented by having each group be its own cohort,
-            and is identical to xarray's default strategy.
+            Same as "cohorts" and will be removed soon.
     engine : {"flox", "numpy", "numba"}, optional
         Algorithm to compute the groupby reduction on non-dask arrays and on each dask chunk:
           * ``"numpy"``:

--- a/flox/core.py
+++ b/flox/core.py
@@ -1087,17 +1087,18 @@ def subset_to_blocks(
         blkshape = array.blocks.shape
 
     unraveled = np.unravel_index(flatblocks, blkshape)
-    normalized = []
+    normalized: list[Union[int, np.ndarray, slice]] = []
     for ax, idx in enumerate(unraveled):
         i = np.unique(idx).squeeze()
         if i.ndim == 0:
-            i_ = i.item()
+            normalized.append(i.item())
         else:
             if np.array_equal(i, np.arange(blkshape[ax])):
-                i_ = slice(None)
+                normalized.append(slice(None))
             elif np.array_equal(i, np.arange(i[0], i[-1] + 1)):
-                i_ = slice(i[0], i[-1] + 1)
-        normalized.append(i_)
+                normalized.append(slice(i[0], i[-1] + 1))
+            else:
+                normalized.append(i)
     full_normalized = (slice(None),) * (array.ndim - len(normalized)) + tuple(normalized)
 
     # has no iterables

--- a/flox/core.py
+++ b/flox/core.py
@@ -1287,11 +1287,11 @@ def dask_groupby_agg(
                     expected_groups_ = _get_expected_groups(by_input, sort=sort)
                 else:
                     expected_groups_ = expected_groups
-            groups = (expected_groups_.to_numpy(),)
+                groups = (expected_groups_.to_numpy(),)
 
         elif method in ["cohorts", "split-reduce"]:
             chunks_cohorts = find_group_cohorts(
-                by, [array.chunks[ax] for ax in axis], merge=True, method=method
+                by_input, [array.chunks[ax] for ax in axis], merge=True, method=method
             )
             reduced_ = []
             groups_ = []

--- a/flox/core.py
+++ b/flox/core.py
@@ -1757,8 +1757,10 @@ def groupby_reduce(
         if sort and method != "map-reduce":
             assert len(groups) == 1
             sorted_idx = np.argsort(groups[0])
-            result = result[..., sorted_idx]
-            groups = (groups[0][sorted_idx],)
+            # This optimization helps specifically with resampling
+            if not (sorted_idx[1:] <= sorted_idx[:-1]).all():
+                result = result[..., sorted_idx]
+                groups = (groups[0][sorted_idx],)
 
     if factorize_early:
         # nan group labels are factorized to -1, and preserved

--- a/flox/visualize.py
+++ b/flox/visualize.py
@@ -136,10 +136,10 @@ def visualize_cohorts_2d(by, array, method="cohorts"):
     print("finding cohorts...")
     before_merged = find_group_cohorts(
         by, [array.chunks[ax] for ax in range(-by.ndim, 0)], merge=False, method=method
-    )
+    ).values()
     merged = find_group_cohorts(
         by, [array.chunks[ax] for ax in range(-by.ndim, 0)], merge=True, method=method
-    )
+    ).values()
     print("finished cohorts...")
 
     xticks = np.cumsum(array.chunks[-1])

--- a/flox/xarray.py
+++ b/flox/xarray.py
@@ -123,9 +123,7 @@ def xarray_reduce(
             method by first rechunking using ``rechunk_for_cohorts``
             (for 1D ``by`` only).
           * ``"split-reduce"``:
-            Break out each group into its own array and then ``"map-reduce"``.
-            This is implemented by having each group be its own cohort,
-            and is identical to xarray's default strategy.
+            Same as "cohorts" and will be removed soon.
     engine : {"flox", "numpy", "numba"}, optional
         Algorithm to compute the groupby reduction on non-dask arrays and on each dask chunk:
           * ``"numpy"``:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -646,11 +646,11 @@ def test_rechunk_for_blockwise(inchunks, expected):
         [[[1, 2, 3, 4]], [1, 2, 3, 1, 2, 3, 4], (3, 4), True],
         [[[1, 2, 3], [4]], [1, 2, 3, 1, 2, 3, 4], (3, 4), False],
         [[[1], [2], [3], [4]], [1, 2, 3, 1, 2, 3, 4], (2, 2, 2, 1), False],
-        [[[3], [2], [1], [4]], [1, 2, 3, 1, 2, 3, 4], (2, 2, 2, 1), True],
+        [[[1], [2], [3], [4]], [1, 2, 3, 1, 2, 3, 4], (2, 2, 2, 1), True],
         [[[1, 2, 3], [4]], [1, 2, 3, 1, 2, 3, 4], (3, 3, 1), True],
         [[[1, 2, 3], [4]], [1, 2, 3, 1, 2, 3, 4], (3, 3, 1), False],
         [
-            [[2, 3, 4, 1], [5], [0]],
+            [[0], [1, 2, 3, 4], [5]],
             np.repeat(np.arange(6), [4, 4, 12, 2, 3, 4]),
             (4, 8, 4, 9, 4),
             True,
@@ -776,11 +776,9 @@ def test_cohorts_nd_by(func, method, axis, engine):
     assert_equal(actual, expected)
 
     actual, groups = groupby_reduce(array, by, sort=False, **kwargs)
-    if method in ("split-reduce", "cohorts"):
-        assert_equal(groups, [4, 3, 40, 2, 31, 1, 30])
-    elif method == "map-reduce":
+    if method == "map-reduce":
         assert_equal(groups, [1, 30, 2, 31, 3, 4, 40])
-    elif method == "blockwise":
+    else:
         assert_equal(groups, [1, 30, 2, 31, 3, 40, 4])
     reindexed = reindex_(actual, groups, pd.Index(sorted_groups))
     assert_equal(reindexed, expected)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -658,12 +658,12 @@ def test_rechunk_for_blockwise(inchunks, expected):
     ],
 )
 def test_find_group_cohorts(expected, labels, chunks, merge):
-    actual = list(find_group_cohorts(labels, (chunks,), merge, method="cohorts"))
+    actual = list(find_group_cohorts(labels, (chunks,), merge, method="cohorts").values())
     assert actual == expected, (actual, expected)
 
-    actual = find_group_cohorts(labels, (chunks,), merge, method="split-reduce")
-    expected = [[label] for label in np.unique(labels)]
-    assert actual == expected, (actual, expected)
+    # actual = find_group_cohorts(labels, (chunks,), merge, method="split-reduce")
+    # expected = [[label] for label in np.unique(labels)]
+    # assert actual == expected, (actual, expected)
 
 
 @requires_dask

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -776,9 +776,9 @@ def test_cohorts_nd_by(func, method, axis, engine):
     assert_equal(actual, expected)
 
     actual, groups = groupby_reduce(array, by, sort=False, **kwargs)
-    if method == "cohorts":
+    if method in ("split-reduce", "cohorts"):
         assert_equal(groups, [4, 3, 40, 2, 31, 1, 30])
-    elif method in ("split-reduce", "map-reduce"):
+    elif method == "map-reduce":
         assert_equal(groups, [1, 30, 2, 31, 3, 4, 40])
     elif method == "blockwise":
         assert_equal(groups, [1, 30, 2, 31, 3, 40, 4])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -658,12 +658,8 @@ def test_rechunk_for_blockwise(inchunks, expected):
     ],
 )
 def test_find_group_cohorts(expected, labels, chunks, merge):
-    actual = list(find_group_cohorts(labels, (chunks,), merge, method="cohorts").values())
+    actual = list(find_group_cohorts(labels, (chunks,), merge).values())
     assert actual == expected, (actual, expected)
-
-    # actual = find_group_cohorts(labels, (chunks,), merge, method="split-reduce")
-    # expected = [[label] for label in np.unique(labels)]
-    # assert actual == expected, (actual, expected)
 
 
 @requires_dask


### PR DESCRIPTION
Closes #140

We apply the cohort "split" step after the blockwise reduction, then use
the tree reduction on each cohort.

We also use the `.blocks` accessor to index out blocks. This is still a
bit inefficient since we split by indexing out regular arrays, so we
could index out blocks that don't contain any cohort members. However,
because we are splitting _after_ the blockwise reduction, the amount of
work duplication can be a lot less than splitting the bare array.

One side-effect is that "split-reduce" is now a synonym for "cohorts".
The reason is that find_group_cohorts returns a dict mapping blocks to
cohorts. We could invert that behaviour but I don't see any benefit to
trying to figure that out.
