### PR TITLE
Support reindexing in simple_combine

### DIFF
--- a/asv_bench/benchmarks/combine.py
+++ b/asv_bench/benchmarks/combine.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import numpy as np
 
 import flox
@@ -7,26 +9,31 @@ from . import parameterized
 N = 1000
 
 
+def _get_combine(combine):
+    if combine == "grouped":
+        return partial(flox.core._grouped_combine, engine="numpy")
+    else:
+        return partial(flox.core._simple_combine, reindex=False)
+
+
 class Combine:
     def setup(self, *args, **kwargs):
         raise NotImplementedError
 
-    @parameterized("kind", ("cohorts", "mapreduce"))
-    def time_combine(self, kind):
-        flox.core._grouped_combine(
+    @parameterized(("kind", "combine"), (("reindexed", "not_reindexed"), ("grouped", "simple")))
+    def time_combine(self, kind, combine):
+        _get_combine(combine)(
             getattr(self, f"x_chunk_{kind}"),
             **self.kwargs,
             keepdims=True,
-            engine="numpy",
         )
 
-    @parameterized("kind", ("cohorts", "mapreduce"))
-    def peakmem_combine(self, kind):
-        flox.core._grouped_combine(
+    @parameterized(("kind", "combine"), (("reindexed", "not_reindexed"), ("grouped", "simple")))
+    def peakmem_combine(self, kind, combine):
+        _get_combine(combine)(
             getattr(self, f"x_chunk_{kind}"),
             **self.kwargs,
             keepdims=True,
-            engine="numpy",
         )
 
 
@@ -47,7 +54,7 @@ class Combine1d(Combine):
             }
 
         # motivated by
-        self.x_chunk_mapreduce = [
+        self.x_chunk_not_reindexed = [
             construct_member(groups)
             for groups in [
                 np.array((1, 2, 3, 4)),
@@ -57,5 +64,7 @@ class Combine1d(Combine):
             * 2
         ]
 
-        self.x_chunk_cohorts = [construct_member(groups) for groups in [np.array((1, 2, 3, 4))] * 4]
+        self.x_chunk_reindexed = [
+            construct_member(groups) for groups in [np.array((1, 2, 3, 4))] * 4
+        ]
         self.kwargs = {"agg": flox.aggregations.mean, "axis": (3,)}

--- a/flox/core.py
+++ b/flox/core.py
@@ -136,7 +136,7 @@ def _get_optimal_chunks_for_groups(chunks, labels):
     return tuple(newchunks)
 
 
-def _unique(a: np.ndarray):
+def _unique(a: np.ndarray) -> np.ndarray:
     """Much faster to use pandas unique and sort the results.
     np.unique sorts before uniquifying and is slow."""
     return np.sort(pd.unique(a.reshape(-1)))
@@ -816,7 +816,7 @@ def _expand_dims(results: IntermediateDict) -> IntermediateDict:
     return results
 
 
-def _find_unique_groups(x_chunk):
+def _find_unique_groups(x_chunk) -> np.ndarray:
     from dask.base import flatten
     from dask.utils import deepmap
 
@@ -824,7 +824,7 @@ def _find_unique_groups(x_chunk):
     unique_groups = unique_groups[~isnull(unique_groups)]
 
     if len(unique_groups) == 0:
-        unique_groups = [np.nan]
+        unique_groups = np.array([np.nan])
     return unique_groups
 
 


### PR DESCRIPTION
- [x] add "grouped" or "simple" in task name and check layer names to make sure we don't regress

This PR allows reindexing inside `_simple_combine` so that we don't need to rerun
the groupby-reduce at every combination stage.

This means we are down to three options (good improvement!)
1. `map-reduce` with `reindex=True`: reindex to expected_groups at blockwise stage, then map-reduce
2. `map-reduce` with `reindex=False`: reindex at combine stage of map-reduce
3. `cohorts`  : start with `reindex=False` at blockwise, and then reindex to cohorts specifically, then tree reduce with `reindex=True`

For 1D combine, we see great improvements for `reindex=True`
`reindex=False` uses 2x more memory but similar time.

Note that the `reindex=False` intermediates are a worst case where there are
no shared groups between the chunks being combined.
This case is actually optimized in `_group_combine` where reindexing is
skipped for reducing along a single axis.

```
[ 68.75%] ··· =========== ========= =========
              --                combine
              ----------- -------------------
                  kind     grouped   combine
              =========== ========= =========
                reindexed      760M      631M
               not-reindexed    981M     1.81G
              =========== ========= =========

[ 75.00%] ··· =========== ========== ===========
              --                 combine
              ----------- ----------------------
                  kind     grouped     combine
              =========== ========== ===========
                reindexed    393±10ms    137±10ms
               not-reindexed   652±10ms   611±400ms
              =========== ========== ===========
```