### PR TITLE
Explicitly install conda in CI

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -59,6 +59,7 @@ jobs:
           environment-name: flox-tests
           extra-specs: |
             python=${{env.PYTHON_VERSION}}
+            conda
           cache-env: true
           cache-env-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
 
@@ -100,6 +101,7 @@ jobs:
           environment-name: xarray-tests
           extra-specs: |
             python=${{env.PYTHON_VERSION}}
+            conda
           cache-env: true
           cache-env-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
       - name: Install xarray

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
           cache-env: true
           extra-specs: |
             python="${{ matrix.python-version }}"
+            conda
       - name: Install flox
         run: |
           python -m pip install -e .
@@ -85,6 +86,7 @@ jobs:
           cache-env: true
           extra-specs: |
             python="${{ matrix.python-version }}"
+            conda
       - name: Install flox
         run: |
           python -m pip install --no-deps -e .
@@ -107,6 +109,7 @@ jobs:
           environment-name: flox-tests
           extra-specs: |
             python="3.10"
+            conda
       - name: Run Tests
         run: |
           pytest -n 2
@@ -130,6 +133,7 @@ jobs:
           cache-env: true
           extra-specs: |
             python="3.10"
+            conda
       - name: Install xarray
         run: |
           python -m pip install --no-deps .


### PR DESCRIPTION
Should fix some windows issues noticed in #151, where listing the conda version info crashed the CI.

Solution from: https://github.com/pydata/xarray/pull/7241#issuecomment-1297003420