### PR TITLE
Don't use deprecated distutils module.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,8 +2,8 @@ import importlib
 from contextlib import contextmanager
 
 import numpy as np
-import pandas as pd
 import packaging.version
+import pandas as pd
 import pytest
 
 pd_types = (pd.Index,)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,9 @@
 import importlib
 from contextlib import contextmanager
-from distutils import version
 
 import numpy as np
 import pandas as pd
+import packaging.version
 import pytest
 
 pd_types = (pd.Index,)
@@ -42,7 +42,7 @@ def LooseVersion(vstring):
     # Our development version is something like '0.10.9+aac7bfc'
     # This function just ignored the git commit id.
     vstring = vstring.split("+")[0]
-    return version.LooseVersion(vstring)
+    return packaging.version.Version(vstring)
 
 
 has_dask, requires_dask = _importorskip("dask")


### PR DESCRIPTION
`tests/__init__.py` still uses the deprecated distutils which will be removed in Python 3.12.

From [What’s New In Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated):
> The entire `distutils` package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages `setuptools` and `packaging`, and most other commonly used APIs are available elsewhere in the standard library (such as [platform](https://docs.python.org/3/library/platform.html#module-platform), [shutil](https://docs.python.org/3/library/shutil.html#module-shutil), [subprocess](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [sysconfig](https://docs.python.org/3/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.

[Porting from Distutils](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools) suggests using [`packaging.version`](https://packaging.pypa.io/en/latest/version.html) instead of `distutils.version`.