### PR TITLE
Optimize `min_count` when `expected_groups` is not provided.

### DIFF
--- a/flox/core.py
+++ b/flox/core.py
@@ -2486,6 +2486,12 @@ def groupby_reduce(
         return (result, groups)
 
     elif not has_dask:
+        if min_count_ == 1:
+            # optimize for pure numpy groupby
+            # We set the fill_value appropriately anyway
+            agg.min_count = None
+            agg.numpy = agg.numpy[:-1]
+
         results = _reduce_blockwise(
             array, by_, agg, expected_groups=expected_, reindex=reindex, sort=sort, **kwargs
         )


### PR DESCRIPTION
xref #363 

Skip reindexing when `expected_groups` is *not* provided. In this case, we detect all available groups anyway.\

This is less impactful than it seems because Xarray *always* sets `expected_groups = (pd.RangeIndex(...),)`.

A solution is to set `min_count=0` upstream for `UniqueGrouper`