### PR TITLE
[draft] Accept Cubed arrays instead of dask

### DIFF
--- a/flox/aggregations.py
+++ b/flox/aggregations.py
@@ -11,7 +11,6 @@ from numpy.typing import DTypeLike
 
 from . import aggregate_flox, aggregate_npg, xrutils
 from . import xrdtypes as dtypes
-from .duck_array_ops import asarray
 
 if TYPE_CHECKING:
     FuncTuple = tuple[Callable | str, ...]

--- a/flox/aggregations.py
+++ b/flox/aggregations.py
@@ -65,7 +65,7 @@ def generic_aggregate(
             f"Expected engine to be one of ['flox', 'numpy', 'numba']. Received {engine} instead."
         )
 
-    group_idx = asarray(group_idx, like=array)
+    group_idx = np.asarray(group_idx, like=array)
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")

--- a/flox/aggregations.py
+++ b/flox/aggregations.py
@@ -11,6 +11,7 @@ from numpy.typing import DTypeLike
 
 from . import aggregate_flox, aggregate_npg, xrutils
 from . import xrdtypes as dtypes
+from .duck_array_ops import asarray
 
 if TYPE_CHECKING:
     FuncTuple = tuple[Callable | str, ...]
@@ -64,7 +65,7 @@ def generic_aggregate(
             f"Expected engine to be one of ['flox', 'numpy', 'numba']. Received {engine} instead."
         )
 
-    group_idx = np.asarray(group_idx, like=array)
+    group_idx = asarray(group_idx, like=array)
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")

--- a/flox/core.py
+++ b/flox/core.py
@@ -1387,7 +1387,7 @@ def dask_groupby_agg(
         inds,
         by,
         inds[-by.ndim :],
-        #concatenate=False,
+        # concatenate=False,
         dtype=array.dtype,  # this is purely for show
         # meta=array._meta,
         align_arrays=False,
@@ -1413,7 +1413,7 @@ def dask_groupby_agg(
             dtype=array.dtype,
             axis=axis,
             keepdims=True,
-            #concatenate=False,
+            # concatenate=False,
         )
         aggregate = partial(_aggregate, combine=combine, agg=agg, fill_value=fill_value)
 
@@ -1498,7 +1498,7 @@ def dask_groupby_agg(
         dtype=agg.dtype["final"],
         key=agg.name,
         name=f"{name}-{token}",
-        #concatenate=False,
+        # concatenate=False,
     )
 
     return (result, groups)
@@ -2018,9 +2018,7 @@ def groupby_reduce(
         # nan group labels are factorized to -1, and preserved
         # now we get rid of them by reindexing
         # This also handles bins with no data
-        reindexed = reindex_(
-            result, from_=groups[0], to=expected_groups, fill_value=fill_value
-        )
+        reindexed = reindex_(result, from_=groups[0], to=expected_groups, fill_value=fill_value)
         result = reshape(reindexed, reindexed.shape[:-1] + grp_shape)
         groups = final_groups
 

--- a/flox/core.py
+++ b/flox/core.py
@@ -1406,8 +1406,6 @@ def dask_groupby_agg(
             combine = partial(_grouped_combine, engine=engine, sort=sort)
             combine_name = "grouped-combine"
 
-        #raise NotImplementedError("reached _tree_reduce call")
-
         tree_reduce = partial(
             chunkmanager.reduction,
             func=lambda x: x,

--- a/flox/duck_array_ops.py
+++ b/flox/duck_array_ops.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+
+def get_array_namespace(x):
+    if hasattr(x, "__array_namespace__"):
+        return x.__array_namespace__()
+    else:
+        return np
+
+
+def reshape(array, shape):
+    xp = get_array_namespace(array)
+    return xp.reshape(array, shape)
+
+
+def asarray(obj, like):
+    xp = get_array_namespace(like)
+    return xp.asarray(obj)

--- a/flox/xrutils.py
+++ b/flox/xrutils.py
@@ -34,9 +34,16 @@ def is_duck_array(value: Any) -> bool:
         hasattr(value, "ndim")
         and hasattr(value, "shape")
         and hasattr(value, "dtype")
-        and hasattr(value, "__array_function__")
-        and hasattr(value, "__array_ufunc__")
+        and (
+            (hasattr(value, "__array_function__") and hasattr(value, "__array_ufunc__"))
+            or hasattr(value, "__array_namespace__")
+        )
     )
+
+
+def is_chunked_array(x) -> bool:
+    """True if dask or cubed"""
+    return is_duck_dask_array(x) or (is_duck_array(x) and hasattr(x, "chunks"))
 
 
 def is_dask_collection(x):


### PR DESCRIPTION
Very very rough changes to see what happens if you try to give flox a `cubed.Array`. Not many changes are required to get the cubed array inputs all the way to the reduction step, but I have not yet been able to run it, so there might be additional incompatibilities that turn up. 

- [x] Would close #224