### PR TITLE
compatibility with `numpy>=2.0`

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -19,7 +19,7 @@ jobs:
   upstream-dev:
     name: upstream-dev
     runs-on: ubuntu-latest
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'test-upstream') && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'test-upstream') && github.event_name == 'pull_request') || github.event_name == 'workflow_dispatch' }}
     defaults:
       run:
         shell: bash -l {0}

--- a/flox/xrdtypes.py
+++ b/flox/xrdtypes.py
@@ -31,17 +31,6 @@ INF = AlwaysGreaterThan()
 NINF = AlwaysLessThan()
 
 
-# Pairs of types that, if both found, should be promoted to object dtype
-# instead of following NumPy's own type-promotion rules. These type promotion
-# rules match pandas instead. For reference, see the NumPy type hierarchy:
-# https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.scalars.html
-PROMOTE_TO_OBJECT = [
-    {np.number, np.character},  # numpy promotes to character
-    {np.bool_, np.character},  # numpy promotes to character
-    {np.bytes_, np.str_},  # numpy promotes to unicode
-]
-
-
 def maybe_promote(dtype):
     """Simpler equivalent of pandas.core.common._maybe_promote
 

--- a/flox/xrdtypes.py
+++ b/flox/xrdtypes.py
@@ -38,7 +38,7 @@ NINF = AlwaysLessThan()
 PROMOTE_TO_OBJECT = [
     {np.number, np.character},  # numpy promotes to character
     {np.bool_, np.character},  # numpy promotes to character
-    {np.bytes_, np.unicode_},  # numpy promotes to unicode
+    {np.bytes_, np.str_},  # numpy promotes to unicode
 ]
 
 


### PR DESCRIPTION
`numpy` version 2 will introduce a few breaking changes, one of which `flox` inherited from `xarray`: the use of `np.unicode_` instead of `np.str_`.

Edit: the `mypy` error should be unrelated
Edit2: this is currently blocking pydata/xarray#8117 (as noted there: `numpy` appears to be a bit unstable as they prepare for the 2.0 release, so not sure how quickly we need to adapt)