### PR TITLE
Significantly faster cohorts detection.

### DIFF
--- a/asv_bench/benchmarks/cohorts.py
+++ b/asv_bench/benchmarks/cohorts.py
@@ -1,8 +1,10 @@
 import dask
 import numpy as np
 import pandas as pd
+import xarray as xr
 
 import flox
+from flox.xarray import xarray_reduce
 
 
 class Cohorts:
@@ -125,3 +127,13 @@ class PerfectMonthlyRechunked(PerfectMonthly):
     def setup(self, *args, **kwargs):
         super().setup()
         super().rechunk()
+
+
+def time_cohorts_era5_single():
+    TIME = 900  # 92044 in Google ARCO ERA5
+    da = xr.DataArray(
+        dask.array.ones((TIME, 721, 1440), chunks=(1, -1, -1)),
+        dims=("time", "lat", "lon"),
+        coords=dict(time=pd.date_range("1959-01-01", freq="6H", periods=TIME)),
+    )
+    xarray_reduce(da, da.time.dt.day, method="cohorts", func="any")

--- a/asv_bench/benchmarks/cohorts.py
+++ b/asv_bench/benchmarks/cohorts.py
@@ -14,7 +14,7 @@ class Cohorts:
         raise NotImplementedError
 
     def time_find_group_cohorts(self):
-        flox.core.find_group_cohorts(self.by, self.array.chunks)
+        flox.core.find_group_cohorts(self.by, [self.array.chunks[ax] for ax in self.axis])
         # The cache clear fails dependably in CI
         # Not sure why
         try:

--- a/flox/core.py
+++ b/flox/core.py
@@ -220,12 +220,12 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
 
     #  Iterate over each block and create a new block of same shape with "chunk number"
     shape = tuple(array.blocks.shape[ax] for ax in axis)
-    blocks = np.empty(math.prod(shape), dtype=object)
+    blocks = np.empty(shape, dtype=object)
     array_chunks = tuple(np.array(c) for c in array.chunks)
-    for idx, blockindex in enumerate(np.ndindex(array.numblocks)):
+    for blockindex in np.ndindex(array.numblocks):
         chunkshape = get_chunk_shape(array_chunks, blockindex)
-        blocks[idx] = np.full(chunkshape, idx)
-    which_chunk = np.block(blocks.reshape(shape).tolist()).reshape(-1)
+        blocks[blockindex] = np.full(chunkshape, np.ravel_multi_index(blockindex, array.numblocks))
+    which_chunk = np.block(blocks.tolist()).reshape(-1)
 
     raveled = labels.reshape(-1)
     # these are chunks where a label is present

--- a/flox/core.py
+++ b/flox/core.py
@@ -238,7 +238,11 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
 
     chunks_cohorts = tlz.groupby(invert, label_chunks.keys())
 
-    if merge:
+    # If our dataset has chunksize one along the axis,
+    # then no merging is possible.
+    single_chunks = all((ac == 1).all() for ac in array_chunks)
+
+    if merge and not single_chunks:
         # First sort by number of chunks occupied by cohort
         sorted_chunks_cohorts = dict(
             sorted(chunks_cohorts.items(), key=lambda kv: len(kv[0]), reverse=True)

--- a/flox/core.py
+++ b/flox/core.py
@@ -214,6 +214,8 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
     #  Iterate over each block and create a new block of same shape with "chunk number"
     shape = tuple(array.blocks.shape[ax] for ax in axis)
     # Use a numpy object array to enable assignment in the loop
+    # TODO: is it possible to just use a nested list?
+    #       That is what we need for `np.block`
     blocks = np.empty(shape, dtype=object)
     array_chunks = tuple(np.array(c) for c in array.chunks)
     for idx, blockindex in enumerate(np.ndindex(array.numblocks)):

--- a/flox/core.py
+++ b/flox/core.py
@@ -222,7 +222,7 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
     shape = tuple(array.blocks.shape[ax] for ax in axis)
     blocks = np.empty(math.prod(shape), dtype=object)
     array_chunks = tuple(np.array(c) for c in array.chunks)
-    for idx, blockindex in enumerate(np.ndindex(array.shape)):
+    for idx, blockindex in enumerate(np.ndindex(array.numblocks)):
         chunkshape = get_chunk_shape(array_chunks, blockindex)
         blocks[idx] = np.full(chunkshape, idx)
     which_chunk = np.block(blocks.reshape(shape).tolist()).reshape(-1)

--- a/flox/core.py
+++ b/flox/core.py
@@ -175,8 +175,8 @@ def _unique(a: np.ndarray) -> np.ndarray:
     return np.sort(pd.unique(a.reshape(-1)))
 
 
-def get_chunk_shape(array_chunks, index):
-    index = tuple(slice(k, k + 1) for k in index)  # type: ignore
+def get_chunk_shape(array_chunks, index: tuple[int, ...]) -> tuple[int, ...]:
+    index = tuple(slice(k, k + 1) for k in index)
     chunks = tuple(c[i] for c, i in zip(array_chunks, index))
     chunkshape = tuple(itertools.chain(*chunks))
     return chunkshape

--- a/flox/core.py
+++ b/flox/core.py
@@ -176,15 +176,6 @@ def _unique(a: np.ndarray) -> np.ndarray:
 
 
 def get_chunk_shape(array_chunks, index):
-    # from dask.array.slicing import normalize_index
-
-    # if not isinstance(index, tuple):
-    #     index = (index,)
-    # if sum(isinstance(ind, (np.ndarray, list)) for ind in index) > 1:
-    #     raise ValueError("Can only slice with a single list")
-    # if any(ind is None for ind in index):
-    #     raise ValueError("Slicing with np.newaxis or None is not supported")
-    # index = normalize_index(index, array.numblocks)
     index = tuple(slice(k, k + 1) for k in index)  # type: ignore
     chunks = tuple(c[i] for c, i in zip(array_chunks, index))
     chunkshape = tuple(itertools.chain(*chunks))


### PR DESCRIPTION
Closes #271 

I was iterating over `array.blocks` to figure out the shape of each chunk.

When indexing this object, it creates a dask array per chunk, which is slow for many reasons
- dask array construction, which is useless
- calling np.array() on a chunks tuple repeatedly in a loop (surprisingly slow!)

Replace with a function that calculates the chunk shape. On the arco era5 with 93044 time chunks, this is a speedup from infinite time to 840ms.
```python
TIME = 92044
da = xr.DataArray(
    dask.array.ones((TIME, 721, 1440), chunks=(1, -1, -1)),
    dims=("time", "lat", "lon"),
    coords=dict(time=pd.date_range("1959-01-01", freq="6H", periods=TIME)),
)
%time xarray_reduce(da, da.time.dt.day, method="cohorts", func="any")
```