### PR TITLE
Use set containment instead of perfect subsets

### DIFF
--- a/asv_bench/benchmarks/cohorts.py
+++ b/asv_bench/benchmarks/cohorts.py
@@ -43,8 +43,11 @@ class Cohorts:
         return len(result.dask.layers)
 
     track_num_tasks.unit = "tasks"  # type: ignore[attr-defined] # Lazy
+    track_num_tasks.repeat = 1  # type: ignore[attr-defined] # Lazy
     track_num_tasks_optimized.unit = "tasks"  # type: ignore[attr-defined] # Lazy
+    track_num_tasks_optimized.repeat = 1  # type: ignore[attr-defined] # Lazy
     track_num_layers.unit = "layers"  # type: ignore[attr-defined] # Lazy
+    track_num_layers.repeat = 1  # type: ignore[attr-defined] # Lazy
 
 
 class NWMMidwest(Cohorts):

--- a/asv_bench/benchmarks/cohorts.py
+++ b/asv_bench/benchmarks/cohorts.py
@@ -86,7 +86,7 @@ class ERA5DayOfYear(ERA5Dataset, Cohorts):
 class ERA5DayOfYearRechunked(ERA5DayOfYear, Cohorts):
     def setup(self, *args, **kwargs):
         super().setup()
-        super().rechunk()
+        self.array = dask.array.random.random((721, 1440, len(self.time)), chunks=(-1, -1, 24))
 
 
 class ERA5MonthHour(ERA5Dataset, Cohorts):

--- a/asv_bench/benchmarks/cohorts.py
+++ b/asv_bench/benchmarks/cohorts.py
@@ -47,8 +47,8 @@ class Cohorts:
     track_num_layers.unit = "layers"  # type: ignore[attr-defined] # Lazy
     for f in [track_num_tasks, track_num_tasks_optimized, track_num_layers]:
         f.repeat = 1  # type: ignore[attr-defined] # Lazy
-        f.rounds = 1
-        f.number = 1
+        f.rounds = 1  # type: ignore[attr-defined] # Lazy
+        f.number = 1  # type: ignore[attr-defined] # Lazy
 
 
 class NWMMidwest(Cohorts):

--- a/asv_bench/benchmarks/cohorts.py
+++ b/asv_bench/benchmarks/cohorts.py
@@ -43,11 +43,12 @@ class Cohorts:
         return len(result.dask.layers)
 
     track_num_tasks.unit = "tasks"  # type: ignore[attr-defined] # Lazy
-    track_num_tasks.repeat = 1  # type: ignore[attr-defined] # Lazy
     track_num_tasks_optimized.unit = "tasks"  # type: ignore[attr-defined] # Lazy
-    track_num_tasks_optimized.repeat = 1  # type: ignore[attr-defined] # Lazy
     track_num_layers.unit = "layers"  # type: ignore[attr-defined] # Lazy
-    track_num_layers.repeat = 1  # type: ignore[attr-defined] # Lazy
+    for f in [track_num_tasks, track_num_tasks_optimized, track_num_layers]:
+        f.repeat = 1  # type: ignore[attr-defined] # Lazy
+        f.rounds = 1
+        f.number = 1
 
 
 class NWMMidwest(Cohorts):

--- a/asv_bench/benchmarks/reduce.py
+++ b/asv_bench/benchmarks/reduce.py
@@ -59,17 +59,17 @@ class ChunkReduce:
             expected_groups=expected_groups[expected_name],
         )
 
-    @skip_for_params(numbagg_skip)
-    @parameterize({"func": funcs, "expected_name": expected_names, "engine": engines})
-    def peakmem_reduce(self, func, expected_name, engine):
-        flox.groupby_reduce(
-            self.array,
-            self.labels,
-            func=func,
-            engine=engine,
-            axis=self.axis,
-            expected_groups=expected_groups[expected_name],
-        )
+    # @skip_for_params(numbagg_skip)
+    # @parameterize({"func": funcs, "expected_name": expected_names, "engine": engines})
+    # def peakmem_reduce(self, func, expected_name, engine):
+    #     flox.groupby_reduce(
+    #         self.array,
+    #         self.labels,
+    #         func=func,
+    #         engine=engine,
+    #         axis=self.axis,
+    #         expected_groups=expected_groups[expected_name],
+    #     )
 
 
 class ChunkReduce1D(ChunkReduce):

--- a/flox/core.py
+++ b/flox/core.py
@@ -214,7 +214,7 @@ def slices_from_chunks(chunks):
     return product(*slices)
 
 
-@memoize
+# @memoize
 def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
     """
     Finds groups labels that occur together aka "cohorts"
@@ -312,10 +312,13 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
 
         # precompute needed metrics for the quadratic loop below.
         items = tuple((k, len(k), set(k), v) for k, v in sorted_chunks_cohorts.items() if k)
+        import copy
+        items2 = list(copy.deepcopy(items[1:]))
 
         merged_cohorts = {}
         merged_keys: set[tuple] = set()
 
+        # import ipdb; ipdb.set_trace()
         # Now we iterate starting with the longest number of chunks,
         # and then merge in cohorts that are present in a subset of those chunks
         # I think this is suboptimal and must fail at some point.
@@ -327,12 +330,20 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
             new_value = v1
             # iterate in reverse since we expect small cohorts
             # to be most likely merged in to larger ones
-            for k2, len_k2, set_k2, v2 in reversed(items[idx + 1 :]):
-                if k2 not in merged_keys:
-                    if (len(set_k2 & new_key) / len_k2) > 0.75:
-                        new_key |= set_k2
-                        new_value += v2
-                        merged_keys.update((k2,))
+            to_delete = []
+            for idx2, (k2, len_k2, set_k2, v2) in enumerate(reversed(items2)):
+                if v1 == v2 or k1 == k2:
+                    continue
+                if (len(set_k2 & new_key) / len_k2) > 0.75:
+                    new_key |= set_k2
+                    new_value += v2
+                    assert items2[len(items2)-idx2 - 1][0] == k2
+                    to_delete.append(len(items2)-idx2 - 1)
+                    merged_keys.update((k2,))
+            # print(to_delete)
+            for delete in reversed(sorted(to_delete)):
+                del items2[delete]
+
             sorted_ = sorted(new_value)
             merged_cohorts[tuple(sorted(new_key))] = sorted_
             if idx == 0 and (len(sorted_) == nlabels) and (sorted_ == ilabels).all():
@@ -341,6 +352,7 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
         # sort by first label in cohort
         # This will help when sort=True (default)
         # and we have to resort the dask array
+        print(merged_cohorts)
         return dict(sorted(merged_cohorts.items(), key=lambda kv: kv[1][0]))
 
     else:

--- a/flox/core.py
+++ b/flox/core.py
@@ -303,8 +303,8 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
     # If our dataset has chunksize one along the axis,
     # then no merging is possible.
     single_chunks = all(all(a == 1 for a in ac) for ac in chunks)
-
-    if not single_chunks and merge:
+    one_group_per_chunk = (bitmask.sum(axis=1) == 1).all()
+    if not one_group_per_chunk and not single_chunks and merge:
         # First sort by number of chunks occupied by cohort
         sorted_chunks_cohorts = dict(
             sorted(chunks_cohorts.items(), key=lambda kv: len(kv[0]), reverse=True)

--- a/flox/core.py
+++ b/flox/core.py
@@ -321,7 +321,7 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
         # and then merge in cohorts that are present in a subset of those chunks
         # I think this is suboptimal and must fail at some point.
         # But it might work for most cases. There must be a better way...
-        for idx, (k1, set_k1, v1) in enumerate(items):
+        for idx, (k1, len_k1, set_k1, v1) in enumerate(items):
             if k1 in merged_keys:
                 continue
             merged_cohorts[k1] = copy.deepcopy(v1)

--- a/flox/core.py
+++ b/flox/core.py
@@ -311,23 +311,25 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
             sorted(chunks_cohorts.items(), key=lambda kv: len(kv[0]), reverse=True)
         )
 
-        items = tuple((k, set(k), v) for k, v in sorted_chunks_cohorts.items() if k)
+        # precompute needed metrics for the quadratic loop below.
+        items = tuple((k, len(k), set(k), v) for k, v in sorted_chunks_cohorts.items() if k)
 
         merged_cohorts = {}
         merged_keys = set()
-
-        # Now we iterate starting with the longest number of chunks,
-        # and then merge in cohorts that are present in a subset of those chunks
-        # I think this is suboptimal and must fail at some point.
-        # But it might work for most cases. There must be a better way...
-        for idx, (k1, set_k1, v1) in enumerate(items):
+        # Now we iterate over cohorts starting with the longest number of chunks,
+        # and then merge in cohorts that overlap with the current cohort
+        # Degree of overlap is measured by "set containment".
+        for idx, (k1, len_k1, set_k1, v1) in enumerate(items):
             if k1 in merged_keys:
                 continue
             merged_cohorts[k1] = copy.deepcopy(v1)
-            for k2, set_k2, v2 in items[idx + 1 :]:
-                if k2 not in merged_keys and set_k2.issubset(set_k1):
-                    merged_cohorts[k1].extend(v2)
-                    merged_keys.update((k2,))
+            # iterate in reverse since we expect small cohorts
+            # to be most likely merged in to larger ones
+            for k2, len_k2, set_k2, v2 in reversed(items[idx + 1 :]):
+                if k2 not in merged_keys:
+                    if (len(set_k2 & set_k1) / len_k2) > 0.75:
+                        merged_cohorts[k1].extend(v2)
+                        merged_keys.update((k2,))
 
         # make sure each cohort is sorted after merging
         sorted_merged_cohorts = {k: sorted(v) for k, v in merged_cohorts.items()}

--- a/flox/core.py
+++ b/flox/core.py
@@ -335,7 +335,7 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
                         merged_keys.update((k2,))
             sorted_ = sorted(new_value)
             merged_cohorts[tuple(sorted(new_key))] = sorted_
-            if idx == 0 and (len(sorted_) == nlabels) and (sorted_ == ilabels).all():
+            if idx == 0 and (len(sorted_) == nlabels) and (np.array(sorted_) == ilabels).all():
                 break
 
         # sort by first label in cohort

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -848,16 +848,16 @@ def test_rechunk_for_blockwise(inchunks, expected):
         ],
     ],
 )
-def test_find_group_cohorts(expected, labels, chunks, merge):
+def test_find_group_cohorts(expected, labels, chunks: tuple[int], merge: bool) -> None:
     actual = list(find_group_cohorts(labels, (chunks,), merge).values())
     assert actual == expected, (actual, expected)
 
 
 @pytest.mark.parametrize("chunksize", [12, 13, 14, 24, 36, 48, 72, 71])
-def test_verify_complex_cohorts(chunksize):
+def test_verify_complex_cohorts(chunksize: int) -> None:
     time = pd.Series(pd.date_range("2016-01-01", "2018-12-31 23:59", freq="H"))
     chunks = (chunksize,) * (len(time) // chunksize)
-    by = time.dt.dayofyear.values
+    by = np.array(time.dt.dayofyear.values)
 
     if len(by) != sum(chunks):
         chunks += (len(by) - sum(chunks),)


### PR DESCRIPTION
xref #180

- [x] Add more tests with complicated cohorts

Containment = |Q & S| / |Q|
where
- |X| is the cardinality of set X
- Q is the query set being tested
- S is the existing set

https://ekzhu.com/datasketch/lshensemble.html#containment