### PR TITLE
Optimize cohorts for blockwise distribution of groups

### DIFF
--- a/flox/core.py
+++ b/flox/core.py
@@ -304,47 +304,48 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
     # then no merging is possible.
     single_chunks = all(all(a == 1 for a in ac) for ac in chunks)
     one_group_per_chunk = (bitmask.sum(axis=1) == 1).all()
-    if not one_group_per_chunk and not single_chunks and merge:
-        # First sort by number of chunks occupied by cohort
-        sorted_chunks_cohorts = dict(
-            sorted(chunks_cohorts.items(), key=lambda kv: len(kv[0]), reverse=True)
-        )
-
-        # precompute needed metrics for the quadratic loop below.
-        items = tuple((k, len(k), set(k), v) for k, v in sorted_chunks_cohorts.items() if k)
-
-        merged_cohorts = {}
-        merged_keys: set[tuple] = set()
-
-        # Now we iterate starting with the longest number of chunks,
-        # and then merge in cohorts that are present in a subset of those chunks
-        # I think this is suboptimal and must fail at some point.
-        # But it might work for most cases. There must be a better way...
-        for idx, (k1, len_k1, set_k1, v1) in enumerate(items):
-            if k1 in merged_keys:
-                continue
-            new_key = set_k1
-            new_value = v1
-            # iterate in reverse since we expect small cohorts
-            # to be most likely merged in to larger ones
-            for k2, len_k2, set_k2, v2 in reversed(items[idx + 1 :]):
-                if k2 not in merged_keys:
-                    if (len(set_k2 & new_key) / len_k2) > 0.75:
-                        new_key |= set_k2
-                        new_value += v2
-                        merged_keys.update((k2,))
-            sorted_ = sorted(new_value)
-            merged_cohorts[tuple(sorted(new_key))] = sorted_
-            if idx == 0 and (len(sorted_) == nlabels) and (np.array(sorted_) == ilabels).all():
-                break
-
-        # sort by first label in cohort
-        # This will help when sort=True (default)
-        # and we have to resort the dask array
-        return dict(sorted(merged_cohorts.items(), key=lambda kv: kv[1][0]))
-
-    else:
+    # every group is contained to one block, we should be using blockwise here.
+    every_group_one_block = (bitmask.sum(axis=0) == 1).all()
+    if every_group_one_block or one_group_per_chunk or single_chunks or not merge:
         return chunks_cohorts
+
+    # First sort by number of chunks occupied by cohort
+    sorted_chunks_cohorts = dict(
+        sorted(chunks_cohorts.items(), key=lambda kv: len(kv[0]), reverse=True)
+    )
+
+    # precompute needed metrics for the quadratic loop below.
+    items = tuple((k, len(k), set(k), v) for k, v in sorted_chunks_cohorts.items() if k)
+
+    merged_cohorts = {}
+    merged_keys: set[tuple] = set()
+
+    # Now we iterate starting with the longest number of chunks,
+    # and then merge in cohorts that are present in a subset of those chunks
+    # I think this is suboptimal and must fail at some point.
+    # But it might work for most cases. There must be a better way...
+    for idx, (k1, len_k1, set_k1, v1) in enumerate(items):
+        if k1 in merged_keys:
+            continue
+        new_key = set_k1
+        new_value = v1
+        # iterate in reverse since we expect small cohorts
+        # to be most likely merged in to larger ones
+        for k2, len_k2, set_k2, v2 in reversed(items[idx + 1 :]):
+            if k2 not in merged_keys:
+                if (len(set_k2 & new_key) / len_k2) > 0.75:
+                    new_key |= set_k2
+                    new_value += v2
+                    merged_keys.update((k2,))
+        sorted_ = sorted(new_value)
+        merged_cohorts[tuple(sorted(new_key))] = sorted_
+        if idx == 0 and (len(sorted_) == nlabels) and (np.array(sorted_) == ilabels).all():
+            break
+
+    # sort by first label in cohort
+    # This will help when sort=True (default)
+    # and we have to resort the dask array
+    return dict(sorted(merged_cohorts.items(), key=lambda kv: kv[1][0]))
 
 
 def rechunk_for_cohorts(


### PR DESCRIPTION
Expected for some resampling workloads

In the future, we should automatically choose blockwise for the user.


```
| Change   | Before [bf936f52] <main>   | After [1f51a343] <cohorts-blockwise-opt>   |   Ratio | Benchmark (Parameter)                                      |
|----------|----------------------------|--------------------------------------------|---------|------------------------------------------------------------|
| -        | 1.86±0.06ms                | 651±10μs                                   |    0.35 | cohorts.PerfectBlockwiseResampling.time_find_group_cohorts |
```