### PR TITLE
Pass expected_groups to find_group_cohorts.

### DIFF
--- a/flox/core.py
+++ b/flox/core.py
@@ -215,7 +215,9 @@ def slices_from_chunks(chunks):
 
 
 @memoize
-def find_group_cohorts(labels, chunks, merge: bool = True, expected_groups: None | pd.RangeIndex = None) -> dict:
+def find_group_cohorts(
+    labels, chunks, merge: bool = True, expected_groups: None | pd.RangeIndex = None
+) -> dict:
     """
     Finds groups labels that occur together aka "cohorts"
 
@@ -1550,7 +1552,10 @@ def dask_groupby_agg(
 
         elif method == "cohorts":
             chunks_cohorts = find_group_cohorts(
-                by_input, [array.chunks[ax] for ax in axis], merge=True, expected_groups=expected_groups,
+                by_input,
+                [array.chunks[ax] for ax in axis],
+                merge=True,
+                expected_groups=expected_groups,
             )
             reduced_ = []
             groups_ = []

--- a/flox/core.py
+++ b/flox/core.py
@@ -276,9 +276,18 @@ def find_group_cohorts(
     cols_array = np.concatenate(cols)
     data = np.broadcast_to(np.array(1, dtype=np.uint8), rows_array.shape)
     bitmask = csc_array((data, (rows_array, cols_array)), dtype=bool, shape=(nchunks, nlabels))
+    CHUNK_AXIS, LABEL_AXIS = 0, 1
+
+    chunks_per_label = bitmask.sum(axis=CHUNK_AXIS)
+    # can happen when `expected_groups` is passed but not all labels are present
+    # (binning, resampling)
+    present_labels = chunks_per_label != 0
+    if not present_labels.all():
+        bitmask = bitmask[..., present_labels]
+
     label_chunks = {
         lab: bitmask.indices[slice(bitmask.indptr[lab], bitmask.indptr[lab + 1])]
-        for lab in range(nlabels)
+        for lab in range(bitmask.shape[-1])
     }
 
     ## numpy bitmask approach, faster than finding uniques, but lots of memory
@@ -308,9 +317,9 @@ def find_group_cohorts(
     # If our dataset has chunksize one along the axis,
     # then no merging is possible.
     single_chunks = all(all(a == 1 for a in ac) for ac in chunks)
-    one_group_per_chunk = (bitmask.sum(axis=1) == 1).all()
+    one_group_per_chunk = (bitmask.sum(axis=LABEL_AXIS) == 1).all()
     # every group is contained to one block, we should be using blockwise here.
-    every_group_one_block = (bitmask.sum(axis=0) == 1).all()
+    every_group_one_block = (chunks_per_label == 1).all()
     if every_group_one_block or one_group_per_chunk or single_chunks or not merge:
         return chunks_cohorts
 

--- a/flox/core.py
+++ b/flox/core.py
@@ -215,7 +215,7 @@ def slices_from_chunks(chunks):
 
 
 @memoize
-def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
+def find_group_cohorts(labels, chunks, merge: bool = True, expected_groups: None | pd.RangeIndex = None) -> dict:
     """
     Finds groups labels that occur together aka "cohorts"
 
@@ -246,7 +246,10 @@ def find_group_cohorts(labels, chunks, merge: bool = True) -> dict:
     nchunks = math.prod(len(c) for c in chunks)
 
     # assumes that `labels` are factorized
-    nlabels = labels.max() + 1
+    if expected_groups is None:
+        nlabels = labels.max() + 1
+    else:
+        nlabels = expected_groups[-1] + 1
 
     labels = np.broadcast_to(labels, shape[-labels.ndim :])
 
@@ -1547,7 +1550,7 @@ def dask_groupby_agg(
 
         elif method == "cohorts":
             chunks_cohorts = find_group_cohorts(
-                by_input, [array.chunks[ax] for ax in axis], merge=True
+                by_input, [array.chunks[ax] for ax in axis], merge=True, expected_groups=expected_groups,
             )
             reduced_ = []
             groups_ = []


### PR DESCRIPTION
Skips finding the `max` of labels, since we already know that. Finding the max takes 30% of the time for the NWM groupby