### PR TITLE
import `normalize_axis_index` from `numpy.lib` on `numpy>=2`

### DIFF
--- a/flox/xrutils.py
+++ b/flox/xrutils.py
@@ -8,7 +8,6 @@ from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
-from numpy.core.multiarray import normalize_axis_index  # type: ignore[attr-defined]
 from packaging.version import Version
 
 try:
@@ -23,6 +22,37 @@ try:
     dask_array_type = dask.array.Array
 except ImportError:
     dask_array_type = ()  # type: ignore[assignment, misc]
+
+
+def module_available(module: str, minversion: Optional[str] = None) -> bool:
+    """Checks whether a module is installed without importing it.
+
+    Use this for a lightweight check and lazy imports.
+
+    Parameters
+    ----------
+    module : str
+        Name of the module.
+
+    Returns
+    -------
+    available : bool
+        Whether the module is installed.
+    """
+    has = importlib.util.find_spec(module) is not None
+    if has:
+        mod = importlib.import_module(module)
+        return Version(mod.__version__) >= Version(minversion) if minversion is not None else True
+    else:
+        return False
+
+
+if module_available("numpy", minversion="2.0.0"):
+    from numpy.lib.array_utils import (  # type: ignore[import-not-found]
+        normalize_axis_tuple,
+    )
+else:
+    from numpy.core.numeric import normalize_axis_tuple  # type: ignore[attr-defined]
 
 
 def asarray(data, xp=np):
@@ -349,26 +379,3 @@ def nanlast(values, axis, keepdims=False):
         return np.expand_dims(result, axis=axis)
     else:
         return result
-
-
-def module_available(module: str, minversion: Optional[str] = None) -> bool:
-    """Checks whether a module is installed without importing it.
-
-    Use this for a lightweight check and lazy imports.
-
-    Parameters
-    ----------
-    module : str
-        Name of the module.
-
-    Returns
-    -------
-    available : bool
-        Whether the module is installed.
-    """
-    has = importlib.util.find_spec(module) is not None
-    if has:
-        mod = importlib.import_module(module)
-        return Version(mod.__version__) >= Version(minversion) if minversion is not None else True
-    else:
-        return False

--- a/flox/xrutils.py
+++ b/flox/xrutils.py
@@ -49,10 +49,10 @@ def module_available(module: str, minversion: Optional[str] = None) -> bool:
 
 if module_available("numpy", minversion="2.0.0"):
     from numpy.lib.array_utils import (  # type: ignore[import-not-found]
-        normalize_axis_tuple,
+        normalize_axis_index,
     )
 else:
-    from numpy.core.numeric import normalize_axis_tuple  # type: ignore[attr-defined]
+    from numpy.core.numeric import normalize_axis_index  # type: ignore[attr-defined]
 
 
 def asarray(data, xp=np):


### PR DESCRIPTION
This currently emits a warning, not an error (i.e. not that urgent), but I did notice this a couple of times in `xarray`'s CI.

I'm not too happy about having to move the definition of `module_available` above the import (`isort` might revert that?), but I didn't know whether it would be fine to move that function to a separate module (*and* I was too lazy to try figuring out a good name for that module).