### PR TITLE
Expand property tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Tests
         id: status
         run: |
-          pytest -n auto --cov=./ --cov-report=xml --hypothesis-profile ci
+          pytest --durations=20 --durations-min=0.5 -n auto --cov=./ --cov-report=xml --hypothesis-profile ci
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v4.5.0
         with:

--- a/flox/aggregate_flox.py
+++ b/flox/aggregate_flox.py
@@ -239,7 +239,7 @@ def ffill(group_idx, array, *, axis, **kwargs):
     (group_starts,) = flag.nonzero()
 
     # https://stackoverflow.com/questions/41190852/most-efficient-way-to-forward-fill-nan-values-in-numpy-array
-    mask = np.isnan(array)
+    mask = isnull(array)
     # modified from the SO answer, just reset the index at the start of every group!
     mask[..., np.asarray(group_starts)] = False
 

--- a/flox/aggregations.py
+++ b/flox/aggregations.py
@@ -654,8 +654,8 @@ class ScanState:
 
 
 def reverse(a: AlignedArrays) -> AlignedArrays:
-    a.group_idx = a.group_idx[::-1]
-    a.array = a.array[::-1]
+    a.group_idx = a.group_idx[..., ::-1]
+    a.array = a.array[..., ::-1]
     return a
 
 

--- a/flox/aggregations.py
+++ b/flox/aggregations.py
@@ -76,7 +76,7 @@ def generic_aggregate(
         try:
             method = getattr(aggregate_flox, func)
         except AttributeError:
-            logger.debug(f"Couldn't find {func} for engine='flox'. Falling back to numpy")
+            # logger.debug(f"Couldn't find {func} for engine='flox'. Falling back to numpy")
             method = get_npg_aggregation(func, engine="numpy")
 
     elif engine == "numbagg":
@@ -94,7 +94,7 @@ def generic_aggregate(
                 method = getattr(aggregate_numbagg, func)
 
         except AttributeError:
-            logger.debug(f"Couldn't find {func} for engine='numbagg'. Falling back to numpy")
+            # logger.debug(f"Couldn't find {func} for engine='numbagg'. Falling back to numpy")
             method = get_npg_aggregation(func, engine="numpy")
 
     elif engine in ["numpy", "numba"]:

--- a/flox/aggregations.py
+++ b/flox/aggregations.py
@@ -158,7 +158,11 @@ def _get_fill_value(dtype, fill_value):
             return np.nan
         # This is madness, but npg checks that fill_value is compatible
         # with array dtype even if the fill_value is never used.
-        elif np.issubdtype(dtype, np.integer):
+        elif (
+            np.issubdtype(dtype, np.integer)
+            or np.issubdtype(dtype, np.timedelta64)
+            or np.issubdtype(dtype, np.datetime64)
+        ):
             return dtypes.get_neg_infinity(dtype, min_for_int=True)
         else:
             return None

--- a/flox/core.py
+++ b/flox/core.py
@@ -2011,7 +2011,7 @@ def _validate_reindex(
                 reindex = True
 
     assert isinstance(reindex, bool)
-    logger.debug("Leaving _validate_reindex: reindex is {}".format(reindex))  # noqa
+    # logger.debug("Leaving _validate_reindex: reindex is {}".format(reindex))  # noqa
 
     return reindex
 

--- a/flox/xrdtypes.py
+++ b/flox/xrdtypes.py
@@ -100,6 +100,7 @@ def get_pos_infinity(dtype, max_for_int=False):
 
     if issubclass(dtype.type, np.integer):
         if max_for_int:
+            dtype = np.int64 if dtype.kind in "Mm" else dtype
             return np.iinfo(dtype).max
         else:
             return np.inf

--- a/flox/xrdtypes.py
+++ b/flox/xrdtypes.py
@@ -125,8 +125,9 @@ def get_neg_infinity(dtype, min_for_int=False):
     fill_value : positive infinity value corresponding to this dtype.
     """
 
-    if np.issubdtype(dtype, (np.timedelta64, np.datetime64)):
-        return dtype.type(np.iinfo(np.int64).min + 1)
+    if is_datetime_like(dtype):
+        unit, _ = np.datetime_data(dtype)
+        return dtype.type(np.iinfo(np.int64).min + 1, unit)
 
     if issubclass(dtype.type, np.floating):
         return -np.inf

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -113,7 +113,7 @@ def assert_equal(a, b, tolerance=None):
     else:
         a_eager, b_eager = a, b
 
-    if a.dtype.kind in "SUMm":
+    if a.dtype.kind in "SUMmO":
         np.testing.assert_equal(a_eager, b_eager)
     else:
         np.testing.assert_allclose(a_eager, b_eager, equal_nan=True, **tolerance)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,3 +28,15 @@ settings.register_profile(
 )
 def engine(request):
     return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        "flox",
+        "numpy",
+        pytest.param("numbagg", marks=requires_numbagg),
+    ],
+)
+def engine_no_numba(request):
+    return request.param

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,0 +1,125 @@
+import cftime
+import dask
+import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
+import numpy as np
+
+from . import ALL_FUNCS, SCIPY_STATS_FUNCS
+
+
+def supported_dtypes() -> st.SearchStrategy[np.dtype]:
+    return (
+        npst.integer_dtypes(endianness="=")
+        | npst.unsigned_integer_dtypes(endianness="=")
+        | npst.floating_dtypes(endianness="=", sizes=(32, 64))
+        | npst.complex_number_dtypes(endianness="=")
+        | npst.datetime64_dtypes(endianness="=")
+        | npst.timedelta64_dtypes(endianness="=")
+        | npst.unicode_string_dtypes(endianness="=")
+    )
+
+
+# TODO: stop excluding everything but U
+array_dtype_st = supported_dtypes().filter(lambda x: x.kind not in "cmMU")
+by_dtype_st = supported_dtypes()
+
+NON_NUMPY_FUNCS = ["first", "last", "nanfirst", "nanlast", "count", "any", "all"] + list(
+    SCIPY_STATS_FUNCS
+)
+SKIPPED_FUNCS = ["var", "std", "nanvar", "nanstd"]
+
+func_st = st.sampled_from(
+    [f for f in ALL_FUNCS if f not in NON_NUMPY_FUNCS and f not in SKIPPED_FUNCS]
+)
+numeric_arrays = npst.arrays(
+    elements={"allow_subnormal": False}, shape=npst.array_shapes(), dtype=array_dtype_st
+)
+all_arrays = npst.arrays(
+    elements={"allow_subnormal": False}, shape=npst.array_shapes(), dtype=supported_dtypes()
+)
+
+
+calendars = st.sampled_from(
+    [
+        "standard",
+        "gregorian",
+        "proleptic_gregorian",
+        "noleap",
+        "365_day",
+        "360_day",
+        "julian",
+        "all_leap",
+        "366_day",
+    ]
+)
+
+
+@st.composite
+def units(draw, *, calendar: str):
+    choices = ["days", "hours", "minutes", "seconds", "milliseconds", "microseconds"]
+    if calendar == "360_day":
+        choices += ["months"]
+    elif calendar == "noleap":
+        choices += ["common_years"]
+    time_units = draw(st.sampled_from(choices))
+
+    dt = draw(st.datetimes())
+    year, month, day = dt.year, dt.month, dt.day
+    if calendar == "360_day":
+        day = min(day, 30)
+    return f"{time_units} since {year}-{month}-{day}"
+
+
+@st.composite
+def cftime_arrays(draw, *, shape, calendars=calendars, elements=None):
+    if elements is None:
+        elements = {"min_value": -10_000, "max_value": 10_000}
+    cal = draw(calendars)
+    values = draw(npst.arrays(dtype=np.int64, shape=shape, elements=elements))
+    unit = draw(units(calendar=cal))
+    return cftime.num2date(values, units=unit, calendar=cal)
+
+
+def by_arrays(shape, *, elements=None):
+    return st.one_of(
+        npst.arrays(
+            dtype=npst.integer_dtypes(endianness="=") | npst.unicode_string_dtypes(endianness="="),
+            shape=shape,
+            elements=elements,
+        ),
+        cftime_arrays(shape=shape, elements=elements),
+    )
+
+
+@st.composite
+def chunks(draw, *, shape: tuple[int, ...]) -> tuple[tuple[int, ...], ...]:
+    chunks = []
+    for size in shape:
+        if size > 1:
+            nchunks = draw(st.integers(min_value=1, max_value=size - 1))
+            dividers = sorted(
+                set(draw(st.integers(min_value=1, max_value=size - 1)) for _ in range(nchunks - 1))
+            )
+            chunks.append(tuple(a - b for a, b in zip(dividers + [size], [0] + dividers)))
+        else:
+            chunks.append((1,))
+    return tuple(chunks)
+
+
+@st.composite
+def chunked_arrays(draw, *, chunks=chunks, arrays=numeric_arrays, from_array=dask.array.from_array):
+    array = draw(arrays)
+    chunks = draw(chunks(shape=array.shape))
+
+    if array.dtype.kind in "cf":
+        nan_idx = draw(
+            st.lists(
+                st.integers(min_value=0, max_value=array.shape[-1] - 1),
+                max_size=array.shape[-1] - 1,
+                unique=True,
+            )
+        )
+        if nan_idx:
+            array[..., nan_idx] = np.nan
+
+    return from_array(array, chunks=chunks)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -187,7 +187,7 @@ def test_groupby_reduce(
     assert_equal(expected_result, result)
 
 
-def gen_array_by(size, func: str):
+def gen_array_by(size, func):
     by = np.ones(size[-1])
     rng = np.random.default_rng(12345)
     array = rng.random(tuple(6 if s == 1 else s for s in size))

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -159,14 +159,19 @@ def test_ffill_bfill_reverse(data, array: dask.array.Array) -> None:
     def reverse(arr):
         return arr[..., ::-1]
 
-    for a in (array, array.compute()):
-        forward = groupby_scan(a, by, func="ffill")
-        backward_reversed = reverse(groupby_scan(reverse(a), reverse(by), func="bfill"))
-        assert_equal(forward, backward_reversed)
+    forward = groupby_scan(array, by, func="ffill")
+    as_numpy = groupby_scan(array.compute(), by, func="ffill")
+    assert_equal(forward, as_numpy)
 
-        backward = groupby_scan(a, by, func="bfill")
-        forward_reversed = reverse(groupby_scan(reverse(a), reverse(by), func="ffill"))
-        assert_equal(forward_reversed, backward)
+    backward = groupby_scan(array, by, func="bfill")
+    as_numpy = groupby_scan(array.compute(), by, func="bfill")
+    assert_equal(backward, as_numpy)
+
+    backward_reversed = reverse(groupby_scan(reverse(array), reverse(by), func="bfill"))
+    assert_equal(forward, backward_reversed)
+
+    forward_reversed = reverse(groupby_scan(reverse(array), reverse(by), func="ffill"))
+    assert_equal(forward_reversed, backward)
 
 
 @given(

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -3,7 +3,9 @@ import pytest
 
 pytest.importorskip("hypothesis")
 pytest.importorskip("dask")
+pytest.importorskip("cftime")
 
+import cftime
 import dask
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
@@ -66,11 +68,55 @@ all_arrays = npst.arrays(
     elements={"allow_subnormal": False}, shape=npst.array_shapes(), dtype=supported_dtypes()
 )
 
+calendars = st.sampled_from(
+    [
+        "standard",
+        "gregorian",
+        "proleptic_gregorian",
+        "noleap",
+        "365_day",
+        "360_day",
+        "julian",
+        "all_leap",
+        "366_day",
+    ]
+)
 
-def by_arrays(shape):
-    return npst.arrays(
-        dtype=npst.integer_dtypes(endianness="=") | npst.unicode_string_dtypes(endianness="="),
-        shape=shape,
+
+@st.composite
+def units(draw, *, calendar: str):
+    choices = ["days", "hours", "minutes", "seconds", "milliseconds", "microseconds"]
+    if calendar == "360_day":
+        choices += ["months"]
+    elif calendar == "noleap":
+        choices += ["common_years"]
+    time_units = draw(st.sampled_from(choices))
+
+    dt = draw(st.datetimes())
+    year, month, day = dt.year, dt.month, dt.day
+    if calendar == "360_day":
+        month %= 30
+    return f"{time_units} since {year}-{month}-{day}"
+
+
+@st.composite
+def cftime_arrays(draw, *, shape, calendars=calendars, elements=None):
+    if elements is None:
+        elements = {"min_value": -10_000, "max_value": 10_000}
+    cal = draw(calendars)
+    values = draw(npst.arrays(dtype=np.int64, shape=shape, elements=elements))
+    unit = draw(units(calendar=cal))
+    return cftime.num2date(values, units=unit, calendar=cal)
+
+
+def by_arrays(shape, *, elements=None):
+    return st.one_of(
+        npst.arrays(
+            dtype=npst.integer_dtypes(endianness="=") | npst.unicode_string_dtypes(endianness="="),
+            shape=shape,
+            elements=elements,
+        ),
+        cftime_arrays(shape=shape, elements=elements),
     )
 
 
@@ -85,52 +131,6 @@ def not_overflowing_array(array) -> bool:
     result = bool(np.all((array < info.max / array.size) & (array > info.min / array.size)))
     # note(f"returning {result}, {array.min()} vs {info.min}, {array.max()} vs {info.max}")
     return result
-
-
-@given(array=numeric_arrays, dtype=by_dtype_st, func=func_st)
-def test_groupby_reduce(array, dtype, func):
-    # overflow behaviour differs between bincount and sum (for example)
-    assume(not_overflowing_array(array))
-    # TODO: fix var for complex numbers upstream
-    assume(not (("quantile" in func or "var" in func or "std" in func) and array.dtype.kind == "c"))
-    # arg* with nans in array are weird
-    assume("arg" not in func and not np.any(np.isnan(array).ravel()))
-
-    axis = -1
-    by = np.ones((array.shape[-1],), dtype=dtype)
-    kwargs = {"q": 0.8} if "quantile" in func else {}
-    flox_kwargs = {}
-    with np.errstate(invalid="ignore", divide="ignore"):
-        actual, _ = groupby_reduce(
-            array, by, func=func, axis=axis, engine="numpy", **flox_kwargs, finalize_kwargs=kwargs
-        )
-
-        # numpy-groupies always does the calculation in float64
-        if (
-            ("var" in func or "std" in func or "sum" in func or "mean" in func)
-            and array.dtype.kind == "f"
-            and array.dtype.itemsize != 8
-        ):
-            # bincount always accumulates in float64,
-            # casting to float64 handles std more like npg does.
-            # Setting dtype=float64 works fine for sum, mean.
-            cast_to = array.dtype
-            array = array.astype(np.float64)
-            note(f"casting array to float64, cast_to={cast_to!r}")
-        else:
-            cast_to = None
-        note(("kwargs:", kwargs, "cast_to:", cast_to))
-        expected = getattr(np, func)(array, axis=axis, keepdims=True, **kwargs)
-        if cast_to is not None:
-            note(("casting to:", cast_to))
-            expected = expected.astype(cast_to)
-            actual = actual.astype(cast_to)
-
-    note(("expected: ", expected, "actual: ", actual))
-    tolerance = (
-        {"rtol": 1e-13, "atol": 1e-15} if "var" in func or "std" in func else {"atol": 1e-15}
-    )
-    assert_equal(expected, actual, tolerance)
 
 
 @st.composite
@@ -165,6 +165,65 @@ def chunked_arrays(draw, *, chunks=chunks, arrays=numeric_arrays, from_array=das
             array[..., nan_idx] = np.nan
 
     return from_array(array, chunks=chunks)
+
+
+# TODO: migrate to by_arrays but with constant value
+@given(data=st.data(), array=numeric_arrays, func=func_st)
+def test_groupby_reduce(data, array, func):
+    # overflow behaviour differs between bincount and sum (for example)
+    assume(not_overflowing_array(array))
+    # TODO: fix var for complex numbers upstream
+    assume(not (("quantile" in func or "var" in func or "std" in func) and array.dtype.kind == "c"))
+    # arg* with nans in array are weird
+    assume("arg" not in func and not np.any(np.isnan(array).ravel()))
+
+    axis = -1
+    by = data.draw(
+        by_arrays(
+            elements={
+                "alphabet": st.just("a"),
+                "min_value": 1,
+                "max_value": 1,
+                "min_size": 1,
+                "max_size": 1,
+            },
+            shape=array.shape[-1],
+        )
+    )
+    assert len(np.unique(by)) == 1
+    kwargs = {"q": 0.8} if "quantile" in func else {}
+    flox_kwargs = {}
+    with np.errstate(invalid="ignore", divide="ignore"):
+        actual, _ = groupby_reduce(
+            array, by, func=func, axis=axis, engine="numpy", **flox_kwargs, finalize_kwargs=kwargs
+        )
+
+        # numpy-groupies always does the calculation in float64
+        if (
+            ("var" in func or "std" in func or "sum" in func or "mean" in func)
+            and array.dtype.kind == "f"
+            and array.dtype.itemsize != 8
+        ):
+            # bincount always accumulates in float64,
+            # casting to float64 handles std more like npg does.
+            # Setting dtype=float64 works fine for sum, mean.
+            cast_to = array.dtype
+            array = array.astype(np.float64)
+            note(f"casting array to float64, cast_to={cast_to!r}")
+        else:
+            cast_to = None
+        note(("kwargs:", kwargs, "cast_to:", cast_to))
+        expected = getattr(np, func)(array, axis=axis, keepdims=True, **kwargs)
+        if cast_to is not None:
+            note(("casting to:", cast_to))
+            expected = expected.astype(cast_to)
+            actual = actual.astype(cast_to)
+
+    note(("expected: ", expected, "actual: ", actual))
+    tolerance = (
+        {"rtol": 1e-13, "atol": 1e-15} if "var" in func or "std" in func else {"atol": 1e-15}
+    )
+    assert_equal(expected, actual, tolerance)
 
 
 @given(

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Callable
 
 import pandas as pd
@@ -51,7 +52,9 @@ def not_overflowing_array(array: np.ndarray[Any, Any]) -> bool:
 
     array = array.ravel()
     array = array[notnull(array)]
-    result = bool(np.all((array < info.max / array.size) & (array > info.min / array.size)))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        result = bool(np.all((array < info.max / array.size) & (array > info.min / array.size)))
     # note(f"returning {result}, {array.min()} vs {info.min}, {array.max()} vs {info.max}")
     return result
 


### PR DESCRIPTION
Closes #29

1. Adds coverage for `first` and `last`.
2. Fixes `not_overflowing_array` to work with NaNs! This is a big one.
3. Add more array dtypes to more tests.
4. Turns out `bfill` was quite broken!
5. refactor out hypothesis strategies