### PR TITLE
Cubed fixes

### DIFF
--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -2,7 +2,7 @@ name: flox-doc
 channels:
   - conda-forge
 dependencies:
-  - cubed>=0.14.3
+  - cubed>=0.20.0
   - cubed-xarray
   - dask-core
   - pip

--- a/ci/env-numpy1.yml
+++ b/ci/env-numpy1.yml
@@ -6,7 +6,7 @@ dependencies:
   - cachey
   - cftime
   - codecov
-  - cubed>=0.14.3
+  - cubed>=0.20.0
   - dask-core
   - pandas
   - numpy<2

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - cachey
   - cftime
   - codecov
-  - cubed>=0.14.3
+  - cubed>=0.20.0
   - dask-core
   - pandas
   - numpy>=1.22
@@ -27,4 +27,4 @@ dependencies:
   - numbagg>=0.3
   - hypothesis
   - xarray
-  - zarr<3 # unpin when cubed is fixed.
+  - zarr

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1284,7 +1284,6 @@ def test_group_by_datetime(engine, method):
     assert_equal(expected, actual)
 
 
-@pytest.mark.xfail
 @requires_cubed
 @pytest.mark.parametrize("method", ["blockwise", "map-reduce"])
 def test_group_by_datetime_cubed(engine, method):


### PR DESCRIPTION
Cubed 0.20.0 supports Zarr Python v3 (https://github.com/cubed-dev/cubed/pull/656), and fixes the bug in groupby (https://github.com/cubed-dev/cubed/pull/669).