### PR TITLE
Bump versions following SPEC-0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         env: ["environment"]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
         include:
           - os: "windows-latest"
             env: "environment"
@@ -36,10 +36,10 @@ jobs:
             python-version: "3.13"
           - os: "ubuntu-latest"
             env: "minimal-requirements"
-            python-version: "3.10"
+            python-version: "3.11"
           - os: "windows-latest"
             env: "env-numpy1"
-            python-version: "3.10"
+            python-version: "3.11"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ venv.bak/
 .mypy_cache/
 
 .DS_Store
+
+# Git worktrees
+worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,151 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**flox** is a Python library providing fast GroupBy reduction operations for `dask.array`. It implements parallel-friendly GroupBy reductions using the MapReduce paradigm and integrates with xarray for labeled multidimensional arrays.
+
+## Development Commands
+
+### Environment Setup
+
+```bash
+# Create and activate development environment
+mamba env create -f ci/environment.yml
+conda activate flox-tests
+python -m pip install --no-deps -e .
+```
+
+### Testing
+
+```bash
+# Run full test suite (as used in CI)
+pytest --durations=20 --durations-min=0.5 -n auto --cov=./ --cov-report=xml --hypothesis-profile ci
+
+# Run tests without coverage
+pytest -n auto
+
+# Run single test file
+pytest tests/test_core.py
+
+# Run specific test
+pytest tests/test_core.py::test_function_name
+```
+
+### Code Quality
+
+```bash
+# Run all pre-commit hooks
+pre-commit run --all-files
+
+# Format code with ruff
+ruff format .
+
+# Lint and fix with ruff
+ruff check --fix .
+
+# Type checking
+mypy flox/
+
+# Spell checking
+codespell
+```
+
+### Benchmarking
+
+```bash
+# Performance benchmarking (from asv_bench/ directory)
+cd asv_bench
+asv run
+asv publish
+asv preview
+```
+
+## CI Configuration
+
+### GitHub Workflows (`.github/workflows/`)
+
+- **`ci.yaml`** - Main CI pipeline with test matrix across Python versions (3.11, 3.13) and operating systems (Ubuntu, Windows)
+- **`ci-additional.yaml`** - Additional CI jobs including doctests and mypy type checking
+- **`upstream-dev-ci.yaml`** - Tests against development versions of upstream dependencies
+- **`pypi.yaml`** - PyPI publishing workflow
+- **`testpypi-release.yaml`** - Test PyPI release workflow
+- **`benchmarks.yml`** - Performance benchmarking workflow
+
+### Environment Files (`ci/`)
+
+- **`environment.yml`** - Main test environment with all dependencies
+- **`minimal-requirements.yml`** - Minimal requirements testing (pandas==1.5, numpy==1.22, etc.)
+- **`no-dask.yml`** - Testing without dask dependency
+- **`no-numba.yml`** - Testing without numba dependency
+- **`no-xarray.yml`** - Testing without xarray dependency
+- **`env-numpy1.yml`** - Testing with numpy\<2 constraint
+- **`docs.yml`** - Documentation building environment
+- **`upstream-dev-env.yml`** - Development versions of dependencies
+- **`benchmark.yml`** - Benchmarking environment
+
+### ReadTheDocs Configuration
+
+- **`.readthedocs.yml`** - ReadTheDocs configuration using `ci/docs.yml` environment
+
+## Code Architecture
+
+### Core Modules (`flox/`)
+
+- **`core.py`** - Main reduction logic, central orchestrator of groupby operations
+- **`aggregations.py`** - Defines the `Aggregation` class and built-in aggregation operations
+- **`xarray.py`** - Primary integration with xarray, provides `xarray_reduce()` API
+- **`dask_array_ops.py`** - Dask-specific array operations and optimizations
+
+### Aggregation Backends (`flox/aggregate_*.py`)
+
+- **`aggregate_flox.py`** - Native flox implementation
+- **`aggregate_npg.py`** - numpy-groupies backend
+- **`aggregate_numbagg.py`** - numbagg backend for JIT-compiled operations
+- **`aggregate_sparse.py`** - Support for sparse arrays
+
+### Utilities
+
+- **`cache.py`** - Caching mechanisms for performance
+- **`visualize.py`** - Tools for visualizing groupby operations
+- **`lib.py`** - General utility functions
+- **`xrutils.py`** & **`xrdtypes.py`** - xarray-specific utilities and types
+
+### Main APIs
+
+- `flox.groupby_reduce()` - Pure dask array interface
+- `flox.xarray.xarray_reduce()` - Pure xarray interface
+
+## Key Design Patterns
+
+**Engine Selection**: The library supports multiple computation backends ("flox", "numpy", "numbagg") that can be chosen based on data characteristics and performance requirements.
+
+**MapReduce Strategy**: Implements groupby reductions using a two-stage approach (blockwise + tree reduction) to avoid expensive sort/shuffle operations in parallel computing.
+
+**Chunking Intelligence**: Automatically rechunks data to optimize groupby operations, particularly important for the current `auto-blockwise-rechunk` branch.
+
+**Integration Testing**: Extensive testing against xarray's groupby functionality to ensure compatibility with the broader scientific Python ecosystem.
+
+## Testing Configuration
+
+- **Framework**: pytest with coverage, parallel execution (pytest-xdist), and property-based testing (hypothesis)
+- **Coverage Target**: 95%
+- **Test Environments**: Multiple conda environments test optional dependencies (no-dask, no-numba, no-xarray)
+- **CI Matrices**: Tests across Python 3.11-3.13, Ubuntu/Windows, multiple dependency configurations
+
+## Dependencies
+
+**Core**: pandas>=1.5, numpy>=1.22, numpy_groupies>=0.9.19, scipy>=1.9, toolz, packaging>=21.3
+
+**Optional**: cachey, dask, numba, numbagg, xarray (enable with `pip install flox[all]`)
+
+## Development Notes
+
+- Uses `setuptools_scm` for automatic versioning from git tags
+- Heavy emphasis on performance with ASV benchmarking infrastructure
+- Type hints throughout with mypy checking
+- Pre-commit hooks enforce code quality (ruff, prettier, codespell)
+- Integration testing with xarray upstream development branch
+- **Python Support**: Minimum version 3.11 (updated from 3.10)
+- **Git Worktrees**: `worktrees/` directory is ignored for development workflows

--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -7,7 +7,7 @@ dependencies:
   - dask-core
   - pip
   - xarray
-  - numpy>=1.22
+  - numpy>=1.26
   - scipy
   - numpydoc
   - numpy_groupies>=0.9.19

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - cubed>=0.20.0
   - dask-core
   - pandas
-  - numpy>=1.22
+  - numpy>=1.26
   - scipy
   - sparse
   - lxml # for mypy coverage report

--- a/ci/minimal-requirements.yml
+++ b/ci/minimal-requirements.yml
@@ -13,6 +13,6 @@ dependencies:
   - numpy==1.22
   - scipy==1.9.0
   - numpy_groupies==0.9.19
-  - pandas==1.5
+  - pandas==2.0
   - pooch
   - toolz

--- a/ci/minimal-requirements.yml
+++ b/ci/minimal-requirements.yml
@@ -10,9 +10,9 @@ dependencies:
   - pytest-pretty
   - pytest-xdist
   - syrupy
-  - numpy==1.22
-  - scipy==1.9.0
+  - numpy==1.26
+  - scipy==1.12
   - numpy_groupies==0.9.19
-  - pandas==2.0
+  - pandas==2.1
   - pooch
   - toolz

--- a/ci/no-dask.yml
+++ b/ci/no-dask.yml
@@ -6,7 +6,7 @@ dependencies:
   - pandas
   - hypothesis
   - cftime
-  - numpy>=1.22
+  - numpy>=1.26
   - scipy
   - sparse
   - pip

--- a/ci/no-numba.yml
+++ b/ci/no-numba.yml
@@ -9,7 +9,7 @@ dependencies:
   - dask-core
   - hypothesis
   - pandas
-  - numpy>=1.22
+  - numpy>=1.26
   - scipy
   - sparse
   - lxml # for mypy coverage report

--- a/ci/no-xarray.yml
+++ b/ci/no-xarray.yml
@@ -5,7 +5,7 @@ dependencies:
   - codecov
   - syrupy
   - pandas
-  - numpy>=1.22
+  - numpy>=1.26
   - scipy
   - sparse
   - pip

--- a/docs/source/xarray.md
+++ b/docs/source/xarray.md
@@ -11,22 +11,4 @@ ds.groupby_bins("lon", bins=[0, 10, 20]).mean(method="map-reduce")
 ds.resample(time="M").mean(method="blockwise")
 ```
 
-Xarray's GroupBy operations are currently limited:
-
-1. One can only group by a single variable.
-1. When grouping by a dask array, that array will be computed to discover the unique group labels, and their locations
-
-These limitations can be avoided by using {py:func}`flox.xarray.xarray_reduce` which allows grouping by multiple variables, lazy grouping by dask variables,
-as well as an arbitrary combination of categorical grouping and binning. For example,
-
-```python
-flox.xarray.xarray_reduce(
-    ds,
-    ds.time.dt.month,
-    ds.lon,
-    func="mean",
-    expected_groups=[None, [0, 10, 20]],
-    isbin=[False, True],
-    method="map-reduce",
-)
-```
+{py:func}`flox.xarray.xarray_reduce` used to provide extra functionality, but now Xarray's GroupBy object has been upgraded to match those capabilities with better API!

--- a/flox/core.py
+++ b/flox/core.py
@@ -6,7 +6,6 @@ import itertools
 import logging
 import math
 import operator
-import sys
 import warnings
 from collections import namedtuple
 from collections.abc import Callable, Sequence
@@ -71,13 +70,6 @@ HAS_NUMBAGG = module_available("numbagg", minversion="0.3.0")
 HAS_SPARSE = module_available("sparse")
 
 if TYPE_CHECKING:
-    try:
-        if sys.version_info < (3, 11):
-            from typing_extensions import Unpack
-        else:
-            from typing import Unpack
-    except (ModuleNotFoundError, ImportError):
-        Unpack: Any  # type: ignore[no-redef]
     from .types import CubedArray, DaskArray, Graph
 
     T_DuckArray: TypeAlias = np.ndarray | DaskArray | CubedArray  # Any ?
@@ -2500,7 +2492,7 @@ def groupby_reduce(
     engine: T_EngineOpt = None,
     reindex: ReindexStrategy | bool | None = None,
     finalize_kwargs: dict[Any, Any] | None = None,
-) -> tuple[DaskArray, Unpack[tuple[np.ndarray | DaskArray, ...]]]:
+) -> tuple[DaskArray, *tuple[np.ndarray | DaskArray, ...]]:
     """
     GroupBy reductions using tree reductions for dask.array
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "flox"
 description = "GroupBy operations for dask.array"
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 keywords = ["xarray", "dask", "groupby"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -11,7 +11,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -62,7 +61,7 @@ write_to_template= '__version__ = "{version}"'
 
 [tool.ruff]
 line-length = 110
-target-version = "py310"
+target-version = "py311"
 builtins = ["ellipsis"]
 exclude = [
     ".eggs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ select = [
     "I",
     # Pyupgrade
     "UP",
+    # flake8-tidy-imports
+    "TID",
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "pandas>=1.5",
+    "pandas>=2.0",
     "packaging>=21.3",
     "numpy>=1.22",
     "numpy_groupies>=0.9.19",
@@ -38,7 +38,7 @@ test = ["netCDF4"]
 
 [build-system]
 requires = [
-    "pandas>=1.5",
+    "pandas>=2.0",
     "numpy>=1.22",
     "numpy_groupies>=0.9.19",
     "scipy>=1.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "pandas>=2.0",
+    "pandas>=2.1",
     "packaging>=21.3",
-    "numpy>=1.22",
+    "numpy>=1.26",
     "numpy_groupies>=0.9.19",
     "toolz",
-    "scipy>=1.9",
+    "scipy>=1.12",
 ]
 dynamic=["version"]
 
@@ -38,10 +38,10 @@ test = ["netCDF4"]
 
 [build-system]
 requires = [
-    "pandas>=2.0",
-    "numpy>=1.22",
+    "pandas>=2.1",
+    "numpy>=1.26",
     "numpy_groupies>=0.9.19",
-    "scipy>=1.9",
+    "scipy>=1.12",
     "toolz",
     "setuptools>=61.0.0",
     "setuptools_scm[toml]>=7.0",


### PR DESCRIPTION
## Summary
- Update minimum Python version from 3.10 to 3.11 in pyproject.toml and CI workflows
- Bump dependency versions: numpy>=1.26, scipy>=1.12, pandas>=2.1
- Add ruff TID rule for absolute imports
- Fix typing imports for Python 3.11+ compatibility
- Add worktrees/ to .gitignore
- Add CLAUDE.md with CI and environment documentation

🤖 Generated with [Claude Code](https://claude.ai/code)